### PR TITLE
feat: add PR block/warn report for CI policy enforcement visibility

### DIFF
--- a/pr_block_warn_report/README.md
+++ b/pr_block_warn_report/README.md
@@ -1,0 +1,85 @@
+# PR Block/Warn Report
+
+Generates a report of PR scans that triggered action policy enforcement (block or warn) across a namespace. The report links `ScanRequest` metadata with `ScanResult` to determine the enforcement outcome using `blocking_findings` and `warning_findings` fields.
+
+There are two ways to use this tool:
+
+1. **CLI** (`main.py`) — generates a CSV report directly
+2. **Dashboard** (`dashboard.py`) — interactive Streamlit app with filters, timeline charts, and CSV export
+
+## Prerequisites
+
+- `endorctl` installed and available in your PATH
+- Authenticated to the target namespace
+- Python 3.8+
+
+## CLI Usage
+
+```bash
+pip install -r requirements.txt  # only needed for dashboard
+python main.py -n <namespace> [--days 30]
+```
+
+### Parameters
+
+- **-n, --namespace** (required): Namespace/tenant to query
+- **--days** (optional): Number of days to look back (default: 30)
+
+### Example
+
+```bash
+python main.py -n "acme-corp" --days 14
+```
+
+Output is written to `generated_reports/pr_block_warn_<namespace>_<timestamp>.csv`.
+
+## Dashboard Usage
+
+```bash
+pip install -r requirements.txt
+streamlit run dashboard.py
+```
+
+The dashboard provides:
+
+- **Summary metrics**: total block/warn PRs, breakdown by outcome, projects affected
+- **Filters**: by project, outcome (block/warn), and free-text search
+- **Timeline chart**: daily block/warn counts over time
+- **Top projects**: ranked by enforcement frequency
+- **Data table**: full details with clickable project and PR links
+- **CSV export**: download filtered results
+
+## How It Works
+
+1. Queries `ScanRequest` objects that completed successfully with a `ci_run_uuid`
+2. For each scan, fetches the linked `ScanResult` via `spec.environment.config.ExecutionID`
+3. Classifies outcome from `ScanResult`:
+   - `spec.blocking_findings` non-empty → **block**
+   - `spec.warning_findings` non-empty → **warn**
+4. Resolves project UUIDs to repository names
+5. Outputs results ordered by date (most recent first)
+
+The linkage between models is:
+- `ScanRequest.spec.result.ci_run_uuid` → `ScanResult.spec.environment.config.ExecutionID`
+
+## Output Columns
+
+| Column | Description |
+|---|---|
+| date | When the PR scan was scheduled |
+| project_name | Repository full name (e.g., `org/repo`) |
+| project_url | Link to project in Endor Labs UI |
+| pr_url | Link to the pull request |
+| outcome | `block` or `warn` |
+| blocker_findings | Count of blocking findings from ScanResult |
+| warning_findings | Count of warning findings from ScanResult |
+| exit_code | Exit code from the scan result |
+| policies_triggered | Action policies that were triggered |
+| pr_check_conclusion | PR check run conclusion from the scan request |
+| ci_run_uuid | CI run UUID linking ScanRequest to ScanResult |
+
+## Notes
+
+- The script makes one `ScanResult` query per PR scan. For namespaces with many PR scans, the CLI run may take several minutes.
+- Only PR scans where the linked `ScanResult` has at least one blocking or warning finding are included.
+- `ScanResult` is the primary source of truth for block/warn classification. `Finding` tags (`FINDING_TAGS_CI_BLOCKER`, `FINDING_TAGS_CI_WARNING`) can be used as a fallback if `ScanResult` linkage is incomplete.

--- a/pr_block_warn_report/dashboard.py
+++ b/pr_block_warn_report/dashboard.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+PR Block/Warn Report - Streamlit Dashboard
+
+Interactive dashboard for exploring PR scans that triggered action policy
+enforcement (block or warn). Provides filters, timeline charts, and CSV export.
+"""
+
+import subprocess
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict, Any, Optional
+
+import streamlit as st
+import pandas as pd
+
+
+UI_BASE = "https://app.endorlabs.com"
+
+
+def run_endorctl(args: List[str], namespace: str, timeout: int = 120) -> Optional[Dict[str, Any]]:
+    """Execute an endorctl command and return parsed JSON."""
+    cmd = ["endorctl", "-n", namespace] + args
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=timeout)
+        if result.stdout.strip():
+            return json.loads(result.stdout)
+        return None
+    except subprocess.CalledProcessError as e:
+        st.error(f"endorctl error: {e.stderr}")
+        return None
+    except subprocess.TimeoutExpired:
+        st.error(f"Command timed out: {' '.join(cmd)}")
+        return None
+    except json.JSONDecodeError as e:
+        st.error(f"JSON parse error: {e}")
+        return None
+
+
+def fetch_enforced_scan_results(namespace: str, days: int) -> List[Dict[str, Any]]:
+    """Fetch ScanResults that have blocking or warning findings."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    filter_expr = (
+        "(spec.blocking_findings exists or spec.warning_findings exists)"
+        ' and context.type == "CONTEXT_TYPE_CI_RUN"'
+        f' and meta.create_time > date("{cutoff}")'
+    )
+
+    response = run_endorctl(
+        [
+            "api", "list", "-r", "ScanResult",
+            "--filter", filter_expr,
+            "--field-mask", (
+                "uuid,"
+                "meta.create_time,"
+                "meta.parent_uuid,"
+                "meta.tags,"
+                "tenant_meta.namespace,"
+                "context.tags,"
+                "spec.status,"
+                "spec.blocking_findings,"
+                "spec.warning_findings"
+            ),
+            "--sort-path", "meta.create_time",
+            "--sort-order", "descending",
+            "--list-all",
+            "-t", "300s",
+        ],
+        namespace,
+        timeout=360,
+    )
+
+    if not response:
+        return []
+    return response.get("list", {}).get("objects", [])
+
+
+def extract_pr_number(scan_result: Dict[str, Any]) -> Optional[str]:
+    """Extract PR number from context.tags or meta.tags (e.g. 'pr=1')."""
+    for tag_source in [scan_result.get("context", {}).get("tags", []),
+                       scan_result.get("meta", {}).get("tags", [])]:
+        for tag in tag_source:
+            if tag.startswith("pr="):
+                return tag.split("=", 1)[1]
+    return None
+
+
+def resolve_project_info(namespace: str, project_uuids: List[str]) -> Dict[str, Dict[str, str]]:
+    """Resolve project UUIDs to full_name and http_clone_url."""
+    if not project_uuids:
+        return {}
+
+    uuid_list = "', '".join(project_uuids)
+    response = run_endorctl(
+        [
+            "api", "list", "-r", "Project",
+            "--filter", f"uuid in ['{uuid_list}']",
+            "--field-mask", "uuid,spec.git.full_name,spec.git.http_clone_url",
+            "--list-all",
+        ],
+        namespace,
+        timeout=120,
+    )
+
+    if not response:
+        return {}
+
+    projects = {}
+    for obj in response.get("list", {}).get("objects", []):
+        git = obj.get("spec", {}).get("git", {})
+        clone_url = git.get("http_clone_url", "")
+        base_url = clone_url.rstrip("/").removesuffix(".git") if clone_url else ""
+        projects[obj.get("uuid", "")] = {
+            "full_name": git.get("full_name", "Unknown"),
+            "base_url": base_url,
+        }
+
+    return projects
+
+
+def build_pr_url(base_url: str, pr_number: Optional[str]) -> str:
+    """Construct PR URL from project base URL and PR number."""
+    if not base_url or not pr_number:
+        return "N/A"
+    return f"{base_url}/pull/{pr_number}"
+
+
+def run_analysis(namespace: str, days: int) -> pd.DataFrame:
+    """Fetch data and build the report DataFrame."""
+    # Step 1: Get ScanResults with block/warn (small, targeted query)
+    scan_results = fetch_enforced_scan_results(namespace, days)
+
+    if not scan_results:
+        st.warning("No ScanResults with block/warn findings found.")
+        return pd.DataFrame()
+
+    st.info(f"Found {len(scan_results)} ScanResults with block/warn findings.")
+
+    # Step 2: Resolve project info in bulk
+    project_uuids = list(set(
+        sr.get("meta", {}).get("parent_uuid", "")
+        for sr in scan_results
+        if sr.get("meta", {}).get("parent_uuid")
+    ))
+    project_info = resolve_project_info(namespace, project_uuids)
+
+    # Step 3: Build rows
+    rows = []
+    for sr in scan_results:
+        sr_uuid = sr.get("uuid", "")
+        meta = sr.get("meta", {})
+        spec = sr.get("spec", {})
+        ns = sr.get("tenant_meta", {}).get("namespace", namespace)
+        project_uuid = meta.get("parent_uuid", "")
+        proj = project_info.get(project_uuid, {"full_name": "Unknown", "base_url": ""})
+
+        blocking = spec.get("blocking_findings", [])
+        warning = spec.get("warning_findings", [])
+        outcome = "block" if blocking else "warn"
+
+        pr_number = extract_pr_number(sr)
+
+        rows.append({
+            "date": meta.get("create_time", ""),
+            "project_name": proj["full_name"],
+            "project_url": f"{UI_BASE}/t/{ns}/projects/{project_uuid}",
+            "pr_url": build_pr_url(proj["base_url"], pr_number),
+            "scan_result_url": f"{UI_BASE}/t/{ns}/scan-history/{sr_uuid}",
+            "outcome": outcome,
+            "blocker_findings": len(blocking),
+            "warning_findings": len(warning),
+            "pr_check_conclusion": spec.get("status", ""),
+        })
+
+    if not rows:
+        st.warning("No PR scans with block or warn findings in this time range.")
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df = df.sort_values("date", ascending=False).reset_index(drop=True)
+    return df
+
+
+def main():
+    st.set_page_config(
+        page_title="PR Block/Warn Report",
+        page_icon="🔒",
+        layout="wide",
+        initial_sidebar_state="expanded",
+    )
+
+    # Session state init
+    if "df" not in st.session_state:
+        st.session_state.df = None
+
+    st.title("PR Block/Warn Report")
+    st.markdown("Explore PR scans that triggered action policy enforcement (block or warn).")
+    st.markdown("---")
+
+    # --- Sidebar ---
+    with st.sidebar:
+        st.header("Configuration")
+
+        try:
+            subprocess.run(["endorctl", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            st.success("endorctl available")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            st.error("endorctl not found in PATH")
+            st.stop()
+
+        namespace = st.text_input("Namespace", value="", help="Tenant namespace to query")
+
+        days = st.selectbox(
+            "Lookback period",
+            options=[7, 14, 30, 60, 90],
+            index=2,
+            format_func=lambda d: f"{d} days",
+        )
+
+        generate = st.button("Generate Report", type="primary", use_container_width=True)
+
+    # --- Run analysis ---
+    if generate:
+        if not namespace:
+            st.error("Please enter a namespace.")
+            st.stop()
+
+        with st.spinner("Querying endorctl..."):
+            df = run_analysis(namespace, days)
+
+        st.session_state.df = df
+        st.session_state.namespace = namespace
+        st.session_state.days = days
+        st.rerun()
+
+    # --- Show results ---
+    if st.session_state.df is None or st.session_state.df.empty:
+        if st.session_state.df is not None:
+            st.info("No results to display.")
+        else:
+            st.info("Configure the parameters in the sidebar and click **Generate Report**.")
+        st.stop()
+
+    df = st.session_state.df
+
+    # --- Summary metrics ---
+    st.markdown("## Summary")
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("Total Block/Warn PRs", len(df))
+    col2.metric("Blocked", len(df[df["outcome"] == "block"]))
+    col3.metric("Warned", len(df[df["outcome"] == "warn"]))
+    col4.metric("Projects Affected", df["project_name"].nunique())
+
+    # --- Filters ---
+    st.markdown("## Filters")
+    fcol1, fcol2, fcol3 = st.columns(3)
+
+    with fcol1:
+        projects = ["All"] + sorted(df["project_name"].unique().tolist())
+        selected_project = st.selectbox("Project", projects)
+
+    with fcol2:
+        outcomes = ["All", "block", "warn"]
+        selected_outcome = st.selectbox("Outcome", outcomes)
+
+    with fcol3:
+        search = st.text_input("Search (PR URL, project name)", value="")
+
+    filtered = df.copy()
+    if selected_project != "All":
+        filtered = filtered[filtered["project_name"] == selected_project]
+    if selected_outcome != "All":
+        filtered = filtered[filtered["outcome"] == selected_outcome]
+    if search:
+        mask = (
+            filtered["pr_url"].str.contains(search, case=False, na=False)
+            | filtered["project_name"].str.contains(search, case=False, na=False)
+        )
+        filtered = filtered[mask]
+
+    st.caption(f"Showing {len(filtered)} of {len(df)} results")
+
+    # --- Timeline chart ---
+    st.markdown("## Timeline")
+
+    if not filtered.empty and filtered["date"].notna().any():
+        chart_df = filtered.copy()
+        chart_df["day"] = chart_df["date"].dt.date
+
+        # Daily counts by outcome
+        daily = (
+            chart_df.groupby(["day", "outcome"])
+            .size()
+            .reset_index(name="count")
+        )
+        daily_pivot = daily.pivot(index="day", columns="outcome", values="count").fillna(0)
+
+        st.bar_chart(daily_pivot)
+
+    # --- Top projects ---
+    st.markdown("## Top Projects by Block/Warn Count")
+
+    top_projects = (
+        filtered.groupby("project_name")["outcome"]
+        .value_counts()
+        .unstack(fill_value=0)
+        .assign(total=lambda x: x.sum(axis=1))
+        .sort_values("total", ascending=False)
+        .head(15)
+    )
+
+    if not top_projects.empty:
+        display_cols = [c for c in ["block", "warn", "total"] if c in top_projects.columns]
+        st.dataframe(top_projects[display_cols], use_container_width=True)
+
+    # --- Data table ---
+    st.markdown("## PR Scan Details")
+
+    st.dataframe(
+        filtered,
+        use_container_width=True,
+        height=500,
+        column_config={
+            "date": st.column_config.DatetimeColumn("Date", format="YYYY-MM-DD HH:mm"),
+            "project_name": st.column_config.TextColumn("Project", width="medium"),
+            "project_url": st.column_config.LinkColumn("Project Link", width="small"),
+            "pr_url": st.column_config.LinkColumn("PR URL", width="medium"),
+            "scan_result_url": st.column_config.LinkColumn("Scan Result", width="small"),
+            "outcome": st.column_config.TextColumn("Outcome", width="small"),
+            "blocker_findings": st.column_config.NumberColumn("Blockers", width="small"),
+            "warning_findings": st.column_config.NumberColumn("Warnings", width="small"),
+            "pr_check_conclusion": st.column_config.TextColumn("Conclusion", width="small"),
+        },
+    )
+
+    # --- Export ---
+    st.markdown("## Export")
+
+    csv_data = filtered.to_csv(index=False)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    st.download_button(
+        label="Download CSV",
+        data=csv_data,
+        file_name=f"pr_block_warn_{st.session_state.namespace}_{ts}.csv",
+        mime="text/csv",
+        use_container_width=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pr_block_warn_report/dashboard.py
+++ b/pr_block_warn_report/dashboard.py
@@ -10,11 +10,27 @@ import subprocess
 import json
 import os
 from datetime import datetime, timedelta, timezone
+from io import BytesIO
 from typing import List, Dict, Any, Optional
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 
 import streamlit as st
 import pandas as pd
 import altair as alt
+
+from reportlab.lib.pagesizes import letter, landscape
+from reportlab.lib.units import inch
+from reportlab.lib.colors import HexColor
+from reportlab.platypus import (
+    SimpleDocTemplate, Paragraph, Spacer, Image as RLImage,
+    Table, TableStyle, KeepTogether,
+)
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 
 UI_BASE = "https://app.endorlabs.com"
@@ -188,6 +204,227 @@ def run_analysis(namespace: str, days: int) -> pd.DataFrame:
     df["date"] = pd.to_datetime(df["date"], errors="coerce")
     df = df.sort_values("date", ascending=False).reset_index(drop=True)
     return df
+
+
+BRAND = {
+    "green": "#00D26A",
+    "dark": "#1A1A2E",
+    "block": "#d32f2f",
+    "warn": "#fbc02d",
+    "text_primary": "#1A1A2E",
+    "text_secondary": "#5A6577",
+    "white": "#FFFFFF",
+    "table_header_bg": "#1A1A2E",
+    "table_header_text": "#FFFFFF",
+    "table_row_alt": "#F8F9FA",
+    "table_border": "#DEE2E6",
+}
+
+
+def _fig_to_rl_image(fig, width: float, height: float) -> RLImage:
+    """Convert a matplotlib figure to a ReportLab Image."""
+    buf = BytesIO()
+    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight",
+                facecolor=fig.get_facecolor(), edgecolor="none")
+    plt.close(fig)
+    buf.seek(0)
+    return RLImage(buf, width=width, height=height)
+
+
+def _build_timeline_chart(df: pd.DataFrame, page_width: float) -> RLImage:
+    """Render the timeline bar chart for the PDF."""
+    chart_df = df.copy()
+    chart_df["day"] = chart_df["date"].dt.date
+
+    daily = chart_df.groupby(["day", "outcome"]).size().reset_index(name="count")
+    pivot = daily.pivot(index="day", columns="outcome", values="count").fillna(0)
+    pivot.index = pd.to_datetime(pivot.index)
+
+    fig, ax = plt.subplots(figsize=(page_width / 72, 2.8))
+    fig.set_facecolor(BRAND["white"])
+    ax.set_facecolor(BRAND["white"])
+
+    bar_width = 0.8
+    bottom = None
+    for outcome, color in [("block", BRAND["block"]), ("warn", BRAND["warn"])]:
+        if outcome in pivot.columns:
+            vals = pivot[outcome].values
+            ax.bar(pivot.index, vals, width=bar_width, bottom=bottom,
+                   color=color, label=outcome, edgecolor="none")
+            bottom = vals if bottom is None else bottom + vals
+
+    ax.set_ylabel("Count", fontsize=9, color=BRAND["text_secondary"])
+    ax.legend(fontsize=8, frameon=False)
+    ax.grid(axis="y", linestyle="-", alpha=0.15, color="#AAAAAA")
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_color("#DDDDDD")
+    ax.spines["bottom"].set_color("#DDDDDD")
+    ax.tick_params(colors=BRAND["text_secondary"], labelsize=8)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
+    plt.setp(ax.get_xticklabels(), rotation=30, ha="right", fontsize=8)
+    fig.tight_layout()
+
+    return _fig_to_rl_image(fig, page_width, 2.8 * 72)
+
+
+def generate_pdf(df: pd.DataFrame, namespace: str, days: int) -> bytes:
+    """Generate a branded PDF report and return as bytes."""
+    buf = BytesIO()
+    page_w, page_h = landscape(letter)
+    margin = 0.6 * inch
+    doc = SimpleDocTemplate(buf, pagesize=landscape(letter),
+                            leftMargin=margin, rightMargin=margin,
+                            topMargin=margin, bottomMargin=margin)
+    usable_width = page_w - 2 * margin
+
+    styles = getSampleStyleSheet()
+    styles.add(ParagraphStyle("Title2", parent=styles["Title"],
+                              fontSize=20, textColor=HexColor(BRAND["dark"]),
+                              spaceAfter=4))
+    styles.add(ParagraphStyle("Subtitle", parent=styles["Normal"],
+                              fontSize=10, textColor=HexColor(BRAND["text_secondary"]),
+                              spaceAfter=12))
+    styles.add(ParagraphStyle("SectionHeader", parent=styles["Heading2"],
+                              fontSize=13, textColor=HexColor(BRAND["dark"]),
+                              spaceBefore=16, spaceAfter=8))
+    styles.add(ParagraphStyle("CellText", parent=styles["Normal"],
+                              fontSize=7, leading=9))
+
+    elements = []
+
+    # --- Header ---
+    elements.append(Paragraph("PR Block/Warn Report", styles["Title2"]))
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    elements.append(Paragraph(f"Namespace: {namespace}  |  Lookback: {days} days  |  Generated: {ts}",
+                              styles["Subtitle"]))
+
+    # Green divider
+    divider_data = [["" ]]
+    divider = Table(divider_data, colWidths=[usable_width], rowHeights=[3])
+    divider.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["green"]))]))
+    elements.append(divider)
+    elements.append(Spacer(1, 12))
+
+    # --- Summary cards ---
+    total = len(df)
+    blocked = len(df[df["outcome"] == "block"])
+    warned = len(df[df["outcome"] == "warn"])
+    projects_affected = df["project_name"].nunique()
+
+    summary_data = [
+        ["Total Block/Warn PRs", "Blocked", "Warned", "Projects Affected"],
+        [str(total), str(blocked), str(warned), str(projects_affected)],
+    ]
+    col_w = usable_width / 4
+    summary_table = Table(summary_data, colWidths=[col_w] * 4, rowHeights=[20, 32])
+    summary_table.setStyle(TableStyle([
+        ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica"),
+        ("FONTSIZE", (0, 0), (-1, 0), 9),
+        ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["text_secondary"])),
+        ("FONTNAME", (0, 1), (-1, 1), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 1), (-1, 1), 18),
+        ("TEXTCOLOR", (0, 1), (-1, 1), HexColor(BRAND["text_primary"])),
+        ("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["table_row_alt"])),
+        ("BOX", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+        ("LINEBELOW", (0, 0), (-1, 0), 0.5, HexColor(BRAND["table_border"])),
+    ]))
+    elements.append(summary_table)
+    elements.append(Spacer(1, 12))
+
+    # --- Timeline chart ---
+    if not df.empty and df["date"].notna().any():
+        elements.append(Paragraph("Timeline", styles["SectionHeader"]))
+        chart_img = _build_timeline_chart(df, usable_width)
+        elements.append(chart_img)
+        elements.append(Spacer(1, 8))
+
+    # --- Top projects table ---
+    top_projects = (
+        df.groupby("project_name")["outcome"]
+        .value_counts()
+        .unstack(fill_value=0)
+        .assign(total=lambda x: x.sum(axis=1))
+        .sort_values("total", ascending=False)
+        .head(15)
+    )
+
+    if not top_projects.empty:
+        elements.append(Paragraph("Top Projects by Block/Warn Count", styles["SectionHeader"]))
+        tp_header = ["Project", "Block", "Warn", "Total"]
+        tp_rows = [tp_header]
+        for proj_name, row in top_projects.iterrows():
+            tp_rows.append([
+                Paragraph(str(proj_name), styles["CellText"]),
+                str(int(row.get("block", 0))),
+                str(int(row.get("warn", 0))),
+                str(int(row.get("total", 0))),
+            ])
+
+        tp_col_widths = [usable_width * 0.6, usable_width * 0.13, usable_width * 0.13, usable_width * 0.14]
+        tp_table = Table(tp_rows, colWidths=tp_col_widths, repeatRows=1)
+        tp_style = [
+            ("BACKGROUND", (0, 0), (-1, 0), HexColor(BRAND["table_header_bg"])),
+            ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["table_header_text"])),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, 0), 8),
+            ("FONTSIZE", (0, 1), (-1, -1), 8),
+            ("ALIGN", (1, 0), (-1, -1), "CENTER"),
+            ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+            ("GRID", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+            ("ROWBACKGROUNDS", (0, 1), (-1, -1), [HexColor(BRAND["white"]), HexColor(BRAND["table_row_alt"])]),
+        ]
+        tp_table.setStyle(TableStyle(tp_style))
+        elements.append(tp_table)
+        elements.append(Spacer(1, 12))
+
+    # --- Detail table ---
+    elements.append(Paragraph("PR Scan Details", styles["SectionHeader"]))
+
+    detail_header = ["Date", "Project", "PR URL", "Scan Result", "Outcome", "Blockers", "Warnings"]
+    detail_rows = [detail_header]
+
+    for _, row in df.iterrows():
+        date_str = row["date"].strftime("%Y-%m-%d %H:%M") if pd.notna(row["date"]) else ""
+        detail_rows.append([
+            date_str,
+            Paragraph(str(row["project_name"]), styles["CellText"]),
+            Paragraph(str(row["pr_url"]), styles["CellText"]),
+            Paragraph(str(row["scan_result_url"]), styles["CellText"]),
+            row["outcome"],
+            str(row["blocker_findings"]),
+            str(row["warning_findings"]),
+        ])
+
+    detail_col_widths = [
+        usable_width * 0.11,  # date
+        usable_width * 0.20,  # project
+        usable_width * 0.25,  # pr url
+        usable_width * 0.25,  # scan result
+        usable_width * 0.07,  # outcome
+        usable_width * 0.06,  # blockers
+        usable_width * 0.06,  # warnings
+    ]
+    detail_table = Table(detail_rows, colWidths=detail_col_widths, repeatRows=1)
+    detail_style = [
+        ("BACKGROUND", (0, 0), (-1, 0), HexColor(BRAND["table_header_bg"])),
+        ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["table_header_text"])),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, 0), 7),
+        ("FONTSIZE", (0, 1), (-1, -1), 7),
+        ("ALIGN", (4, 0), (-1, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [HexColor(BRAND["white"]), HexColor(BRAND["table_row_alt"])]),
+    ]
+    detail_table.setStyle(TableStyle(detail_style))
+    elements.append(detail_table)
+
+    # Build PDF
+    doc.build(elements)
+    return buf.getvalue()
 
 
 def main():
@@ -374,13 +611,26 @@ def main():
     csv_data = filtered.to_csv(index=False)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-    st.download_button(
-        label="Download CSV",
-        data=csv_data,
-        file_name=f"pr_block_warn_{st.session_state.namespace}_{ts}.csv",
-        mime="text/csv",
-        use_container_width=True,
-    )
+    ecol1, ecol2 = st.columns(2)
+
+    with ecol1:
+        st.download_button(
+            label="Download CSV",
+            data=csv_data,
+            file_name=f"pr_block_warn_{st.session_state.namespace}_{ts}.csv",
+            mime="text/csv",
+            use_container_width=True,
+        )
+
+    with ecol2:
+        pdf_data = generate_pdf(filtered, st.session_state.namespace, st.session_state.days)
+        st.download_button(
+            label="Download PDF",
+            data=pdf_data,
+            file_name=f"pr_block_warn_{st.session_state.namespace}_{ts}.pdf",
+            mime="application/pdf",
+            use_container_width=True,
+        )
 
 
 if __name__ == "__main__":

--- a/pr_block_warn_report/dashboard.py
+++ b/pr_block_warn_report/dashboard.py
@@ -14,6 +14,7 @@ from typing import List, Dict, Any, Optional
 
 import streamlit as st
 import pandas as pd
+import altair as alt
 
 
 UI_BASE = "https://app.endorlabs.com"
@@ -66,6 +67,7 @@ def fetch_enforced_scan_results(namespace: str, days: int) -> List[Dict[str, Any
             "--sort-path", "meta.create_time",
             "--sort-order", "descending",
             "--list-all",
+            "--traverse",
             "-t", "300s",
         ],
         namespace,
@@ -97,8 +99,9 @@ def resolve_project_info(namespace: str, project_uuids: List[str]) -> Dict[str, 
         [
             "api", "list", "-r", "Project",
             "--filter", f"uuid in ['{uuid_list}']",
-            "--field-mask", "uuid,spec.git.full_name,spec.git.http_clone_url",
+            "--field-mask", "uuid,tenant_meta.namespace,spec.git.full_name,spec.git.http_clone_url",
             "--list-all",
+            "--traverse",
         ],
         namespace,
         timeout=120,
@@ -115,6 +118,7 @@ def resolve_project_info(namespace: str, project_uuids: List[str]) -> Dict[str, 
         projects[obj.get("uuid", "")] = {
             "full_name": git.get("full_name", "Unknown"),
             "base_url": base_url,
+            "namespace": obj.get("tenant_meta", {}).get("namespace", ""),
         }
 
     return projects
@@ -152,9 +156,11 @@ def run_analysis(namespace: str, days: int) -> pd.DataFrame:
         sr_uuid = sr.get("uuid", "")
         meta = sr.get("meta", {})
         spec = sr.get("spec", {})
-        ns = sr.get("tenant_meta", {}).get("namespace", namespace)
         project_uuid = meta.get("parent_uuid", "")
-        proj = project_info.get(project_uuid, {"full_name": "Unknown", "base_url": ""})
+        proj = project_info.get(project_uuid, {"full_name": "Unknown", "base_url": "", "namespace": ""})
+
+        # Use the project's namespace for URLs (correct for child namespaces)
+        ns = proj["namespace"] or sr.get("tenant_meta", {}).get("namespace", namespace)
 
         blocking = spec.get("blocking_findings", [])
         warning = spec.get("warning_findings", [])
@@ -213,11 +219,20 @@ def main():
 
         namespace = st.text_input("Namespace", value="", help="Tenant namespace to query")
 
+        lookback_options = {
+            1: "Last 1 day",
+            2: "Last 2 days",
+            3: "Last 3 days",
+            5: "Last 5 days",
+            7: "Last 1 week",
+            14: "Last 2 weeks",
+            21: "Last 3 weeks (max retention)",
+        }
         days = st.selectbox(
             "Lookback period",
-            options=[7, 14, 30, 60, 90],
-            index=2,
-            format_func=lambda d: f"{d} days",
+            options=list(lookback_options.keys()),
+            index=len(lookback_options) - 1,
+            format_func=lambda d: lookback_options[d],
         )
 
         generate = st.button("Generate Report", type="primary", use_container_width=True)
@@ -290,15 +305,32 @@ def main():
         chart_df = filtered.copy()
         chart_df["day"] = chart_df["date"].dt.date
 
-        # Daily counts by outcome
         daily = (
             chart_df.groupby(["day", "outcome"])
             .size()
             .reset_index(name="count")
         )
-        daily_pivot = daily.pivot(index="day", columns="outcome", values="count").fillna(0)
 
-        st.bar_chart(daily_pivot)
+        chart = (
+            alt.Chart(daily)
+            .mark_bar()
+            .encode(
+                x=alt.X("day:T", title="Date"),
+                y=alt.Y("count:Q", title="Count", stack=True),
+                color=alt.Color(
+                    "outcome:N",
+                    scale=alt.Scale(
+                        domain=["block", "warn"],
+                        range=["#d32f2f", "#fbc02d"],
+                    ),
+                    title="Outcome",
+                ),
+                tooltip=["day:T", "outcome:N", "count:Q"],
+            )
+            .properties(height=350)
+        )
+
+        st.altair_chart(chart, use_container_width=True)
 
     # --- Top projects ---
     st.markdown("## Top Projects by Block/Warn Count")

--- a/pr_block_warn_report/main.py
+++ b/pr_block_warn_report/main.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+PR Block/Warn Report Generator - CLI
+
+Generates a CSV report of PR scans that triggered action policy enforcement
+(block or warn) across a namespace. Uses endorctl to query ScanResult and
+Project resources.
+"""
+
+import subprocess
+import json
+import csv
+import sys
+import argparse
+import os
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict, Any, Optional
+
+
+UI_BASE = "https://app.endorlabs.com"
+
+
+def run_endorctl(args: List[str], namespace: str, timeout: int = 120) -> Optional[Dict[str, Any]]:
+    """Execute an endorctl command and return parsed JSON."""
+    cmd = ["endorctl", "-n", namespace] + args
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=timeout,
+        )
+        if result.stdout.strip():
+            return json.loads(result.stdout)
+        return None
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing: {' '.join(cmd)}")
+        print(f"stderr: {e.stderr}")
+        return None
+    except subprocess.TimeoutExpired:
+        print(f"Timeout executing: {' '.join(cmd)}")
+        return None
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON: {e}")
+        return None
+
+
+def get_enforced_scan_results(namespace: str, days: int) -> List[Dict[str, Any]]:
+    """Fetch ScanResults that have blocking or warning findings."""
+    print(f"Fetching ScanResults with block/warn findings (last {days} days)...")
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    filter_expr = (
+        "(spec.blocking_findings exists or spec.warning_findings exists)"
+        ' and context.type == "CONTEXT_TYPE_CI_RUN"'
+        f' and meta.create_time > date("{cutoff}")'
+    )
+
+    response = run_endorctl(
+        [
+            "api", "list", "-r", "ScanResult",
+            "--filter", filter_expr,
+            "--field-mask", (
+                "uuid,"
+                "meta.create_time,"
+                "meta.parent_uuid,"
+                "meta.tags,"
+                "tenant_meta.namespace,"
+                "context.tags,"
+                "spec.status,"
+                "spec.blocking_findings,"
+                "spec.warning_findings"
+            ),
+            "--sort-path", "meta.create_time",
+            "--sort-order", "descending",
+            "--list-all",
+            "-t", "300s",
+        ],
+        namespace,
+        timeout=360,
+    )
+
+    if not response:
+        return []
+
+    objects = response.get("list", {}).get("objects", [])
+    print(f"Found {len(objects)} ScanResults with block/warn findings")
+    return objects
+
+
+def extract_pr_number(scan_result: Dict[str, Any]) -> Optional[str]:
+    """Extract PR number from context.tags or meta.tags (e.g. 'pr=1')."""
+    for tag_source in [scan_result.get("context", {}).get("tags", []),
+                       scan_result.get("meta", {}).get("tags", [])]:
+        for tag in tag_source:
+            if tag.startswith("pr="):
+                return tag.split("=", 1)[1]
+    return None
+
+
+def get_project_info(namespace: str, project_uuids: List[str]) -> Dict[str, Dict[str, str]]:
+    """Resolve project UUIDs to full_name and http_clone_url."""
+    if not project_uuids:
+        return {}
+
+    print(f"Resolving info for {len(project_uuids)} projects...")
+    uuid_list = "', '".join(project_uuids)
+    response = run_endorctl(
+        [
+            "api", "list", "-r", "Project",
+            "--filter", f"uuid in ['{uuid_list}']",
+            "--field-mask", "uuid,spec.git.full_name,spec.git.http_clone_url",
+            "--list-all",
+        ],
+        namespace,
+        timeout=120,
+    )
+
+    if not response:
+        return {}
+
+    projects = {}
+    for obj in response.get("list", {}).get("objects", []):
+        git = obj.get("spec", {}).get("git", {})
+        clone_url = git.get("http_clone_url", "")
+        # Strip .git suffix for clean PR URLs
+        base_url = clone_url.rstrip("/").removesuffix(".git") if clone_url else ""
+        projects[obj.get("uuid", "")] = {
+            "full_name": git.get("full_name", "Unknown"),
+            "base_url": base_url,
+        }
+
+    return projects
+
+
+def build_pr_url(base_url: str, pr_number: Optional[str]) -> str:
+    """Construct PR URL from project base URL and PR number."""
+    if not base_url or not pr_number:
+        return "N/A"
+    return f"{base_url}/pull/{pr_number}"
+
+
+def generate_report(namespace: str, days: int) -> None:
+    """Main report generation logic."""
+    # Step 1: Get ScanResults with block/warn (small, targeted query)
+    scan_results = get_enforced_scan_results(namespace, days)
+    if not scan_results:
+        print("No ScanResults with block/warn findings found.")
+        return
+
+    # Step 2: Collect project UUIDs and resolve in bulk
+    project_uuids = list(set(
+        sr.get("meta", {}).get("parent_uuid", "")
+        for sr in scan_results
+        if sr.get("meta", {}).get("parent_uuid")
+    ))
+    project_info = get_project_info(namespace, project_uuids)
+
+    # Step 3: Build report rows
+    rows = []
+    for sr in scan_results:
+        sr_uuid = sr.get("uuid", "")
+        meta = sr.get("meta", {})
+        spec = sr.get("spec", {})
+        ns = sr.get("tenant_meta", {}).get("namespace", namespace)
+        project_uuid = meta.get("parent_uuid", "")
+        proj = project_info.get(project_uuid, {"full_name": "Unknown", "base_url": ""})
+
+        blocking = spec.get("blocking_findings", [])
+        warning = spec.get("warning_findings", [])
+        outcome = "block" if blocking else "warn"
+
+        pr_number = extract_pr_number(sr)
+
+        rows.append({
+            "date": meta.get("create_time", ""),
+            "project_name": proj["full_name"],
+            "project_url": f"{UI_BASE}/t/{ns}/projects/{project_uuid}",
+            "pr_url": build_pr_url(proj["base_url"], pr_number),
+            "scan_result_url": f"{UI_BASE}/t/{ns}/scan-history/{sr_uuid}",
+            "outcome": outcome,
+            "blocker_findings": len(blocking),
+            "warning_findings": len(warning),
+            "pr_check_conclusion": spec.get("status", ""),
+        })
+
+    # Write CSV
+    os.makedirs("generated_reports", exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"generated_reports/pr_block_warn_{namespace}_{timestamp}.csv"
+
+    fieldnames = [
+        "date", "project_name", "project_url", "pr_url", "scan_result_url",
+        "outcome", "blocker_findings", "warning_findings", "pr_check_conclusion",
+    ]
+
+    with open(filename, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"\nReport generated: {filename}")
+    print(f"Total PR scans with block/warn: {len(rows)}")
+    print(f"  Blocked: {sum(1 for r in rows if r['outcome'] == 'block')}")
+    print(f"  Warned:  {sum(1 for r in rows if r['outcome'] == 'warn')}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a report of PR scans that were blocked or warned by action policies"
+    )
+    parser.add_argument("-n", "--namespace", required=True, help="Namespace/tenant to query")
+    parser.add_argument(
+        "--days", type=int, default=30,
+        help="Number of days to look back (default: 30)"
+    )
+    args = parser.parse_args()
+
+    print(f"PR Block/Warn Report")
+    print(f"Namespace: {args.namespace}")
+    print(f"Lookback:  {args.days} days")
+    print("-" * 50)
+
+    # Check endorctl availability
+    try:
+        subprocess.run(["endorctl", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("Error: endorctl is not available. Please ensure it's installed and in your PATH.")
+        sys.exit(1)
+
+    generate_report(args.namespace, args.days)
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/pr_block_warn_report/main.py
+++ b/pr_block_warn_report/main.py
@@ -14,7 +14,23 @@ import sys
 import argparse
 import os
 from datetime import datetime, timedelta, timezone
+from io import BytesIO
 from typing import List, Dict, Any, Optional
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import pandas as pd
+
+from reportlab.lib.pagesizes import letter, landscape
+from reportlab.lib.units import inch
+from reportlab.lib.colors import HexColor
+from reportlab.platypus import (
+    SimpleDocTemplate, Paragraph, Spacer, Image as RLImage,
+    Table, TableStyle,
+)
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 
 
 UI_BASE = "https://app.endorlabs.com"
@@ -145,7 +161,209 @@ def build_pr_url(base_url: str, pr_number: Optional[str]) -> str:
     return f"{base_url}/pull/{pr_number}"
 
 
-def generate_report(namespace: str, days: int, outcome_filter: str) -> None:
+BRAND = {
+    "green": "#00D26A",
+    "dark": "#1A1A2E",
+    "block": "#d32f2f",
+    "warn": "#fbc02d",
+    "text_primary": "#1A1A2E",
+    "text_secondary": "#5A6577",
+    "white": "#FFFFFF",
+    "table_header_bg": "#1A1A2E",
+    "table_header_text": "#FFFFFF",
+    "table_row_alt": "#F8F9FA",
+    "table_border": "#DEE2E6",
+}
+
+
+def _fig_to_rl_image(fig, width: float, height: float) -> RLImage:
+    buf = BytesIO()
+    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight",
+                facecolor=fig.get_facecolor(), edgecolor="none")
+    plt.close(fig)
+    buf.seek(0)
+    return RLImage(buf, width=width, height=height)
+
+
+def _build_timeline_chart(df: pd.DataFrame, page_width: float) -> RLImage:
+    chart_df = df.copy()
+    chart_df["day"] = chart_df["date"].dt.date
+    daily = chart_df.groupby(["day", "outcome"]).size().reset_index(name="count")
+    pivot = daily.pivot(index="day", columns="outcome", values="count").fillna(0)
+    pivot.index = pd.to_datetime(pivot.index)
+
+    fig, ax = plt.subplots(figsize=(page_width / 72, 2.8))
+    fig.set_facecolor(BRAND["white"])
+    ax.set_facecolor(BRAND["white"])
+
+    bottom = None
+    for outcome, color in [("block", BRAND["block"]), ("warn", BRAND["warn"])]:
+        if outcome in pivot.columns:
+            vals = pivot[outcome].values
+            ax.bar(pivot.index, vals, width=0.8, bottom=bottom,
+                   color=color, label=outcome, edgecolor="none")
+            bottom = vals if bottom is None else bottom + vals
+
+    ax.set_ylabel("Count", fontsize=9, color=BRAND["text_secondary"])
+    ax.legend(fontsize=8, frameon=False)
+    ax.grid(axis="y", linestyle="-", alpha=0.15, color="#AAAAAA")
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_color("#DDDDDD")
+    ax.spines["bottom"].set_color("#DDDDDD")
+    ax.tick_params(colors=BRAND["text_secondary"], labelsize=8)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
+    plt.setp(ax.get_xticklabels(), rotation=30, ha="right", fontsize=8)
+    fig.tight_layout()
+    return _fig_to_rl_image(fig, page_width, 2.8 * 72)
+
+
+def write_pdf(rows: List[Dict[str, Any]], namespace: str, days: int, filename: str) -> None:
+    """Generate a branded PDF report from report rows."""
+    df = pd.DataFrame(rows)
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df = df.sort_values("date", ascending=False).reset_index(drop=True)
+
+    page_w, page_h = landscape(letter)
+    margin = 0.6 * inch
+    usable_width = page_w - 2 * margin
+    doc = SimpleDocTemplate(filename, pagesize=landscape(letter),
+                            leftMargin=margin, rightMargin=margin,
+                            topMargin=margin, bottomMargin=margin)
+
+    styles = getSampleStyleSheet()
+    styles.add(ParagraphStyle("Title2", parent=styles["Title"],
+                              fontSize=20, textColor=HexColor(BRAND["dark"]), spaceAfter=4))
+    styles.add(ParagraphStyle("Subtitle", parent=styles["Normal"],
+                              fontSize=10, textColor=HexColor(BRAND["text_secondary"]), spaceAfter=12))
+    styles.add(ParagraphStyle("SectionHeader", parent=styles["Heading2"],
+                              fontSize=13, textColor=HexColor(BRAND["dark"]),
+                              spaceBefore=16, spaceAfter=8))
+    styles.add(ParagraphStyle("CellText", parent=styles["Normal"], fontSize=7, leading=9))
+
+    elements = []
+
+    # Header
+    elements.append(Paragraph("PR Block/Warn Report", styles["Title2"]))
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    elements.append(Paragraph(
+        f"Namespace: {namespace}  |  Lookback: {days} days  |  Generated: {ts}",
+        styles["Subtitle"]))
+
+    # Green divider
+    divider = Table([[""]], colWidths=[usable_width], rowHeights=[3])
+    divider.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["green"]))]))
+    elements.append(divider)
+    elements.append(Spacer(1, 12))
+
+    # Summary cards
+    total = len(df)
+    blocked = len(df[df["outcome"] == "block"])
+    warned = len(df[df["outcome"] == "warn"])
+    projects_affected = df["project_name"].nunique()
+
+    summary_data = [
+        ["Total Block/Warn PRs", "Blocked", "Warned", "Projects Affected"],
+        [str(total), str(blocked), str(warned), str(projects_affected)],
+    ]
+    col_w = usable_width / 4
+    summary_table = Table(summary_data, colWidths=[col_w] * 4, rowHeights=[20, 32])
+    summary_table.setStyle(TableStyle([
+        ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica"),
+        ("FONTSIZE", (0, 0), (-1, 0), 9),
+        ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["text_secondary"])),
+        ("FONTNAME", (0, 1), (-1, 1), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 1), (-1, 1), 18),
+        ("TEXTCOLOR", (0, 1), (-1, 1), HexColor(BRAND["text_primary"])),
+        ("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["table_row_alt"])),
+        ("BOX", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+        ("LINEBELOW", (0, 0), (-1, 0), 0.5, HexColor(BRAND["table_border"])),
+    ]))
+    elements.append(summary_table)
+    elements.append(Spacer(1, 12))
+
+    # Timeline chart
+    if not df.empty and df["date"].notna().any():
+        elements.append(Paragraph("Timeline", styles["SectionHeader"]))
+        elements.append(_build_timeline_chart(df, usable_width))
+        elements.append(Spacer(1, 8))
+
+    # Top projects
+    top_projects = (
+        df.groupby("project_name")["outcome"]
+        .value_counts()
+        .unstack(fill_value=0)
+        .assign(total=lambda x: x.sum(axis=1))
+        .sort_values("total", ascending=False)
+        .head(15)
+    )
+    if not top_projects.empty:
+        elements.append(Paragraph("Top Projects by Block/Warn Count", styles["SectionHeader"]))
+        tp_rows = [["Project", "Block", "Warn", "Total"]]
+        for proj_name, row in top_projects.iterrows():
+            tp_rows.append([
+                Paragraph(str(proj_name), styles["CellText"]),
+                str(int(row.get("block", 0))),
+                str(int(row.get("warn", 0))),
+                str(int(row.get("total", 0))),
+            ])
+        tp_col_widths = [usable_width * 0.6, usable_width * 0.13, usable_width * 0.13, usable_width * 0.14]
+        tp_table = Table(tp_rows, colWidths=tp_col_widths, repeatRows=1)
+        tp_table.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, 0), HexColor(BRAND["table_header_bg"])),
+            ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["table_header_text"])),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, 0), 8),
+            ("FONTSIZE", (0, 1), (-1, -1), 8),
+            ("ALIGN", (1, 0), (-1, -1), "CENTER"),
+            ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+            ("GRID", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+            ("ROWBACKGROUNDS", (0, 1), (-1, -1),
+             [HexColor(BRAND["white"]), HexColor(BRAND["table_row_alt"])]),
+        ]))
+        elements.append(tp_table)
+        elements.append(Spacer(1, 12))
+
+    # Detail table
+    elements.append(Paragraph("PR Scan Details", styles["SectionHeader"]))
+    detail_rows = [["Date", "Project", "PR URL", "Scan Result", "Outcome", "Blockers", "Warnings"]]
+    for _, row in df.iterrows():
+        date_str = row["date"].strftime("%Y-%m-%d %H:%M") if pd.notna(row["date"]) else ""
+        detail_rows.append([
+            date_str,
+            Paragraph(str(row["project_name"]), styles["CellText"]),
+            Paragraph(str(row["pr_url"]), styles["CellText"]),
+            Paragraph(str(row["scan_result_url"]), styles["CellText"]),
+            row["outcome"],
+            str(row["blocker_findings"]),
+            str(row["warning_findings"]),
+        ])
+    detail_col_widths = [
+        usable_width * 0.11, usable_width * 0.20, usable_width * 0.25,
+        usable_width * 0.25, usable_width * 0.07, usable_width * 0.06, usable_width * 0.06,
+    ]
+    detail_table = Table(detail_rows, colWidths=detail_col_widths, repeatRows=1)
+    detail_table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), HexColor(BRAND["table_header_bg"])),
+        ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["table_header_text"])),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, 0), 7),
+        ("FONTSIZE", (0, 1), (-1, -1), 7),
+        ("ALIGN", (4, 0), (-1, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1),
+         [HexColor(BRAND["white"]), HexColor(BRAND["table_row_alt"])]),
+    ]))
+    elements.append(detail_table)
+
+    doc.build(elements)
+    print(f"PDF report generated: {filename}")
+
+
+def generate_report(namespace: str, days: int, outcome_filter: str, pdf: bool) -> None:
     """Main report generation logic."""
     # Step 1: Get ScanResults with block/warn (small, targeted query)
     scan_results = get_enforced_scan_results(namespace, days)
@@ -202,22 +420,26 @@ def generate_report(namespace: str, days: int, outcome_filter: str) -> None:
     # Write CSV
     os.makedirs("generated_reports", exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    filename = f"generated_reports/pr_block_warn_{namespace}_{timestamp}.csv"
+    csv_filename = f"generated_reports/pr_block_warn_{namespace}_{timestamp}.csv"
 
     fieldnames = [
         "date", "project_name", "project_url", "pr_url", "scan_result_url",
         "outcome", "blocker_findings", "warning_findings", "pr_check_conclusion",
     ]
 
-    with open(filename, "w", newline="", encoding="utf-8") as f:
+    with open(csv_filename, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
 
-    print(f"\nReport generated: {filename}")
+    print(f"\nCSV report generated: {csv_filename}")
     print(f"Total PR scans with block/warn: {len(rows)}")
     print(f"  Blocked: {sum(1 for r in rows if r['outcome'] == 'block')}")
     print(f"  Warned:  {sum(1 for r in rows if r['outcome'] == 'warn')}")
+
+    if pdf:
+        pdf_filename = f"generated_reports/pr_block_warn_{namespace}_{timestamp}.pdf"
+        write_pdf(rows, namespace, days, pdf_filename)
 
 
 def main():
@@ -232,6 +454,10 @@ def main():
     parser.add_argument(
         "--outcome", choices=["all", "block", "warn"], default="all",
         help="Filter by outcome: all (default), block, or warn"
+    )
+    parser.add_argument(
+        "--pdf", action="store_true",
+        help="Also generate a PDF report alongside the CSV"
     )
     args = parser.parse_args()
 
@@ -252,7 +478,7 @@ def main():
         print("Error: endorctl is not available. Please ensure it's installed and in your PATH.")
         sys.exit(1)
 
-    generate_report(args.namespace, args.days, args.outcome)
+    generate_report(args.namespace, args.days, args.outcome, args.pdf)
     print("\nDone!")
 
 

--- a/pr_block_warn_report/main.py
+++ b/pr_block_warn_report/main.py
@@ -76,6 +76,7 @@ def get_enforced_scan_results(namespace: str, days: int) -> List[Dict[str, Any]]
             "--sort-path", "meta.create_time",
             "--sort-order", "descending",
             "--list-all",
+            "--traverse",
             "-t", "300s",
         ],
         namespace,
@@ -111,8 +112,9 @@ def get_project_info(namespace: str, project_uuids: List[str]) -> Dict[str, Dict
         [
             "api", "list", "-r", "Project",
             "--filter", f"uuid in ['{uuid_list}']",
-            "--field-mask", "uuid,spec.git.full_name,spec.git.http_clone_url",
+            "--field-mask", "uuid,tenant_meta.namespace,spec.git.full_name,spec.git.http_clone_url",
             "--list-all",
+            "--traverse",
         ],
         namespace,
         timeout=120,
@@ -130,6 +132,7 @@ def get_project_info(namespace: str, project_uuids: List[str]) -> Dict[str, Dict
         projects[obj.get("uuid", "")] = {
             "full_name": git.get("full_name", "Unknown"),
             "base_url": base_url,
+            "namespace": obj.get("tenant_meta", {}).get("namespace", ""),
         }
 
     return projects
@@ -142,7 +145,7 @@ def build_pr_url(base_url: str, pr_number: Optional[str]) -> str:
     return f"{base_url}/pull/{pr_number}"
 
 
-def generate_report(namespace: str, days: int) -> None:
+def generate_report(namespace: str, days: int, outcome_filter: str) -> None:
     """Main report generation logic."""
     # Step 1: Get ScanResults with block/warn (small, targeted query)
     scan_results = get_enforced_scan_results(namespace, days)
@@ -164,13 +167,19 @@ def generate_report(namespace: str, days: int) -> None:
         sr_uuid = sr.get("uuid", "")
         meta = sr.get("meta", {})
         spec = sr.get("spec", {})
-        ns = sr.get("tenant_meta", {}).get("namespace", namespace)
         project_uuid = meta.get("parent_uuid", "")
-        proj = project_info.get(project_uuid, {"full_name": "Unknown", "base_url": ""})
+        proj = project_info.get(project_uuid, {"full_name": "Unknown", "base_url": "", "namespace": ""})
+
+        # Use the project's namespace for URLs (correct for child namespaces)
+        ns = proj["namespace"] or sr.get("tenant_meta", {}).get("namespace", namespace)
 
         blocking = spec.get("blocking_findings", [])
         warning = spec.get("warning_findings", [])
         outcome = "block" if blocking else "warn"
+
+        # Apply outcome filter
+        if outcome_filter != "all" and outcome != outcome_filter:
+            continue
 
         pr_number = extract_pr_number(sr)
 
@@ -185,6 +194,10 @@ def generate_report(namespace: str, days: int) -> None:
             "warning_findings": len(warning),
             "pr_check_conclusion": spec.get("status", ""),
         })
+
+    if not rows:
+        print("No PR scans matching the specified criteria.")
+        return
 
     # Write CSV
     os.makedirs("generated_reports", exist_ok=True)
@@ -213,15 +226,24 @@ def main():
     )
     parser.add_argument("-n", "--namespace", required=True, help="Namespace/tenant to query")
     parser.add_argument(
-        "--days", type=int, default=30,
-        help="Number of days to look back (default: 30)"
+        "--days", type=int, default=21,
+        help="Number of days to look back (default: 21)"
+    )
+    parser.add_argument(
+        "--outcome", choices=["all", "block", "warn"], default="all",
+        help="Filter by outcome: all (default), block, or warn"
     )
     args = parser.parse_args()
 
     print(f"PR Block/Warn Report")
     print(f"Namespace: {args.namespace}")
     print(f"Lookback:  {args.days} days")
+    print(f"Outcome:   {args.outcome}")
     print("-" * 50)
+
+    if args.days > 21:
+        print("INFO: PR scan results are retained for 3 weeks (21 days).")
+        print(f"      Requesting {args.days} days, but results beyond 21 days may not be available.\n")
 
     # Check endorctl availability
     try:
@@ -230,7 +252,7 @@ def main():
         print("Error: endorctl is not available. Please ensure it's installed and in your PATH.")
         sys.exit(1)
 
-    generate_report(args.namespace, args.days)
+    generate_report(args.namespace, args.days, args.outcome)
     print("\nDone!")
 
 

--- a/pr_block_warn_report/requirements.txt
+++ b/pr_block_warn_report/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.28.0
+pandas>=2.0.0

--- a/pr_block_warn_report/requirements.txt
+++ b/pr_block_warn_report/requirements.txt
@@ -1,2 +1,4 @@
 streamlit>=1.28.0
 pandas>=2.0.0
+matplotlib>=3.7.0
+reportlab>=4.0.0


### PR DESCRIPTION
## Summary

Adds a new script (`pr_block_warn_report/`) that provides visibility into PR scans that were **blocked** or **warned** by action policies across a tenant and its child namespaces. This fills a current gap — there is no built-in reporting surface in the Endor Labs UI to see which PRs triggered policy enforcement, how often, and across which projects over time.

## Problem

When action policies are enforced on PR scans (block or warn), there is no consolidated view to answer:
- Which PRs were blocked or warned?
- Which projects are most affected?
- What does the trend look like over time?

This makes it difficult for teams to assess the impact of their policy configurations, troubleshoot CI pipeline friction, or report on enforcement activity across namespaces.

## Solution

Two interfaces to the same data pipeline, depending on use case:

### CLI (`main.py`) — Directed reporting
For scripted or one-off report generation. Outputs CSV by default, with optional PDF.

**Filters:**
- `--namespace` (required) — target tenant, supports parent namespaces via `--traverse`
- `--days` (default: 21) — lookback period, warns if >21 days since PR scan results are retained for 3 weeks
- `--outcome` — `all` (default), `block`, or `warn`
- `--pdf` — also generate a branded PDF report alongside the CSV

**Example:**
```bash
python main.py -n acme-corp --days 14 --outcome block --pdf
```

### Streamlit Dashboard (`dashboard.py`) — Interactive discovery
For drill-down exploration with visual aids. Intended for discovery workflows where you want to filter, search, and explore before exporting.

**Features:**
- Summary metrics (total, blocked, warned, projects affected)
- Interactive filters by project, outcome, and free-text search
- Timeline bar chart with color-coded bars (red = block, yellow = warn)
- Top projects ranked by enforcement frequency
- Full data table with clickable links to projects, PRs, and scan results
- Export filtered results as CSV or PDF

**Lookback options:** 1 day, 2 days, 3 days, 5 days, 1 week, 2 weeks, 3 weeks (max retention)

```bash
pip install -r requirements.txt
streamlit run dashboard.py
```

## How it works

Only 2 API calls regardless of data volume:

1. **ScanResult** query — filters for `blocking_findings` or `warning_findings` existing, scoped to `CONTEXT_TYPE_CI_RUN`, with `--traverse` for child namespace support
2. **Project** query — bulk resolves project UUIDs to repo names and git URLs, also with `--traverse`

PR URLs are constructed from the project's `http_clone_url` + PR number extracted from `context.tags`. Scan result URLs and project URLs use the project's own namespace (not the input namespace), which is correct when querying from a parent namespace.

## Output columns

| Column | Description |
|---|---|
| date | When the scan completed |
| project_name | Repository full name |
| project_url | Link to project in Endor Labs UI |
| pr_url | Link to the pull request |
| scan_result_url | Link to scan result in Endor Labs UI |
| outcome | `block` or `warn` |
| blocker_findings | Count of blocking findings |
| warning_findings | Count of warning findings |

## Test plan

- [x] Run CLI against a tenant with known block/warn PR scans, verify CSV output matches expected data
- [x] Run CLI with `--pdf` flag, verify PDF contains summary, timeline chart, and detail table
- [x] Run CLI with `--outcome block` and `--outcome warn`, verify filtering works
- [x] Run CLI with `--days 30`, verify retention warning is printed
- [x] Run Streamlit dashboard, verify filters, timeline chart colors (red/yellow), and export buttons work
- [x] Run against a parent namespace, verify child namespace results are included and URLs resolve correctly
