### PR TITLE
AI Credit Dashboard (PDF Export Fixes)

### DIFF
--- a/ai_credit_dashboard/compute.py
+++ b/ai_credit_dashboard/compute.py
@@ -95,3 +95,38 @@ def model_breakdown(df: pd.DataFrame, days: int, now: Optional[datetime] = None)
     total = grouped["cost"].sum()
     grouped["pct_of_window"] = grouped["cost"] / total if total > 0 else 0.0
     return grouped.sort_values("cost", ascending=False).reset_index(drop=True)
+
+
+def daily_series(df: pd.DataFrame, days: int, now: Optional[datetime] = None) -> pd.DataFrame:
+    """One row per calendar day in the trailing `days` window, zero-filled for days without usage.
+
+    Unlike slice_window (which cuts at an exact sub-day timestamp), this buckets by whole
+    UTC calendar day so every day in the window gets a row — needed for evenly-spaced trend charts.
+    Columns: day (datetime64 UTC, ascending), cost (float).
+    """
+    now = now or datetime.now(timezone.utc)
+    end_day = pd.Timestamp(now).normalize()
+    start_day = end_day - pd.Timedelta(days=days - 1)
+    all_days = pd.date_range(start=start_day, end=end_day, freq="D", tz="UTC")
+
+    if df.empty:
+        daily_cost = pd.Series(dtype=float)
+    else:
+        daily_cost = df.groupby(df["accrued_date"].dt.normalize())["llm_cost"].sum()
+
+    result = pd.DataFrame({"day": all_days})
+    result["cost"] = result["day"].map(daily_cost).fillna(0.0)
+    return result
+
+
+_DAY_LOCATOR_INTERVALS = {1: 1, 7: 1, 14: 2, 28: 4, 60: 7, 90: 10}
+
+
+def pick_day_locator_interval(window_days: int) -> int:
+    """Tick spacing (in days) for a daily trend chart's x-axis, tuned per PRESETS window size.
+
+    Matplotlib's default AutoDateLocator picks sub-day tick spacing for narrow date ranges,
+    which produces duplicate day labels when formatted at day precision. An explicit
+    per-window interval keeps ticks aligned to whole days and readable at every window size.
+    """
+    return _DAY_LOCATOR_INTERVALS.get(window_days, max(1, window_days // 9))

--- a/ai_credit_dashboard/dashboard.py
+++ b/ai_credit_dashboard/dashboard.py
@@ -43,6 +43,8 @@ from compute import (
     burn_rate,
     projected_exhaustion_date,
     model_breakdown,
+    daily_series,
+    pick_day_locator_interval,
 )
 
 
@@ -148,10 +150,7 @@ def _fig_to_rl_image(fig, width: float, height: float) -> RLImage:
 
 def _build_trend_chart(usage_df: pd.DataFrame, window_days: int, page_width: float) -> RLImage:
     """Render the daily-cost bar chart for the PDF."""
-    windowed = slice_window(usage_df, window_days)
-    daily = windowed.groupby(windowed["accrued_date"].dt.date)["llm_cost"].sum().reset_index()
-    daily.columns = ["day", "cost"]
-    daily["day"] = pd.to_datetime(daily["day"])
+    daily = daily_series(usage_df, window_days)
 
     fig, ax = plt.subplots(figsize=(page_width / 72, 2.8))
     fig.set_facecolor(BRAND["white"])
@@ -167,6 +166,7 @@ def _build_trend_chart(usage_df: pd.DataFrame, window_days: int, page_width: flo
     ax.spines["left"].set_color("#DDDDDD")
     ax.spines["bottom"].set_color("#DDDDDD")
     ax.tick_params(colors=BRAND["text_secondary"], labelsize=8)
+    ax.xaxis.set_major_locator(mdates.DayLocator(interval=pick_day_locator_interval(window_days)))
     ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
     plt.setp(ax.get_xticklabels(), rotation=30, ha="right", fontsize=8)
     fig.tight_layout()
@@ -381,11 +381,7 @@ def main():
 
     st.markdown("### Trend")
 
-    daily = windowed_df.copy()
-    daily["day"] = daily["accrued_date"].dt.date
-    daily_totals = daily.groupby("day", as_index=False)["llm_cost"].sum()
-    daily_totals["day"] = pd.to_datetime(daily_totals["day"])
-    daily_totals = daily_totals.sort_values("day")
+    daily_totals = daily_series(usage_df, window_days).rename(columns={"cost": "llm_cost"})
     daily_totals["cumulative"] = daily_totals["llm_cost"].cumsum()
 
     bar = alt.Chart(daily_totals).mark_bar(color="#00D26A").encode(

--- a/ai_credit_dashboard/tests/test_compute.py
+++ b/ai_credit_dashboard/tests/test_compute.py
@@ -134,3 +134,54 @@ def test_model_breakdown_empty_df():
 
     assert result.empty
     assert list(result.columns) == ["llm", "cost", "pct_of_window"]
+
+
+def test_daily_series_zero_fills_missing_days():
+    now = datetime(2026, 7, 10, tzinfo=timezone.utc)
+    df = _df([
+        {"accrued_date": "2026-07-07T00:00:00Z", "llm": "gpt", "llm_cost": 0.29},
+        {"accrued_date": "2026-07-10T00:00:00Z", "llm": "gpt", "llm_cost": 18.55},
+    ])
+
+    result = compute.daily_series(df, days=7, now=now)
+
+    assert len(result) == 7
+    assert list(result["day"].dt.strftime("%Y-%m-%d")) == [
+        "2026-07-04", "2026-07-05", "2026-07-06", "2026-07-07",
+        "2026-07-08", "2026-07-09", "2026-07-10",
+    ]
+    costs = dict(zip(result["day"].dt.strftime("%Y-%m-%d"), result["cost"]))
+    assert costs["2026-07-04"] == 0.0
+    assert costs["2026-07-07"] == 0.29
+    assert costs["2026-07-08"] == 0.0
+    assert costs["2026-07-10"] == 18.55
+
+
+def test_daily_series_single_day_window():
+    now = datetime(2026, 7, 9, tzinfo=timezone.utc)
+    df = _df([{"accrued_date": "2026-07-09T00:00:00Z", "llm": "gpt", "llm_cost": 18.84}])
+
+    result = compute.daily_series(df, days=1, now=now)
+
+    assert len(result) == 1
+    assert result.iloc[0]["day"].strftime("%Y-%m-%d") == "2026-07-09"
+    assert result.iloc[0]["cost"] == 18.84
+
+
+def test_daily_series_empty_df_still_zero_fills_range():
+    now = datetime(2026, 7, 10, tzinfo=timezone.utc)
+    df = pd.DataFrame(columns=["accrued_date", "llm", "llm_cost"])
+
+    result = compute.daily_series(df, days=3, now=now)
+
+    assert len(result) == 3
+    assert (result["cost"] == 0.0).all()
+
+
+def test_pick_day_locator_interval_matches_presets():
+    assert compute.pick_day_locator_interval(1) == 1
+    assert compute.pick_day_locator_interval(7) == 1
+    assert compute.pick_day_locator_interval(14) == 2
+    assert compute.pick_day_locator_interval(28) == 4
+    assert compute.pick_day_locator_interval(60) == 7
+    assert compute.pick_day_locator_interval(90) == 10


### PR DESCRIPTION
 correct duplicate date labels and sparse gaps in trend charts matplotlib's default AutoDateLocator picks sub-day tick spacing on narrow date ranges, which collapses into repeated day labels once formatted at day precision (e.g. a single day's bar reading as "Jul 09, Jul 09, ..., Jul 10, Jul 10"). Add compute.pick_day_locator_interval, tuned per PRESETS window size, and use it as an explicit DayLocator interval in the PDF's trend chart.

Also add compute.daily_series to zero-fill days without usage, used by both the PDF chart and the interactive Streamlit trend chart, so sparse windows render as evenly-spaced daily bars instead of large gaps.