### PR TITLE
AI SAST Tier Recommender

### DIFF
--- a/ai_sast_tier_recommender/.streamlit/config.toml
+++ b/ai_sast_tier_recommender/.streamlit/config.toml
@@ -1,0 +1,5 @@
+# Pin this app to 8502 so it can run side by side with the ai_credit_dashboard,
+# which uses Streamlit's default 8501. Picked up automatically when you
+# `streamlit run dashboard.py` from this directory; override with --server.port.
+[server]
+port = 8502

--- a/ai_sast_tier_recommender/README.md
+++ b/ai_sast_tier_recommender/README.md
@@ -1,0 +1,111 @@
+# AI SAST Tier Recommender
+
+Interactive Streamlit tool that recommends an AI SAST **tier (1/2/3)** per
+repository in a namespace, maximizing security value while fitting the
+tenant's AI credit budget. It produces an **explainable rationale per repo**
+so a CSE can justify the plan to the customer.
+
+**Advisory only** — it never applies scan profiles or changes quota. It is the
+tier-planning companion to the spend dashboard (`../ai_credit_dashboard`); see
+the design spec at `monorepo/doc/ai-sast-tier-recommender-spec.md` and the
+strategy in `monorepo/doc/ai-sast-rollout-guide.md`.
+
+## Prerequisites
+
+- `endorctl` installed and available in your PATH
+- Authenticated to the target tenant (query at the **root** namespace)
+- Python 3.9+
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+streamlit run dashboard.py
+```
+
+In the sidebar: enter the root tenant namespace, click **Generate/Refresh**,
+then tune the allocation knobs — re-allocation is instant (client-side, no
+re-fetch).
+
+## The tiers (from the rollout guide)
+
+| Tier | SAST configuration | Pool cost |
+|------|--------------------|-----------|
+| **Tier 1** | AI SAST agent (exploitability-aware) | Highest — scales with codebase size |
+| **Tier 2** | Rule-based SAST + AI false-positive triage | Medium — scales with # findings |
+| **Tier 3** | Rule-based (Opengrep) rules only | Zero (free of the pool) |
+
+## How it decides
+
+1. **Language gate (hard):** repos whose supported-language **byte share**
+   (`Repository.spec.languages`) is below the threshold (default 50%) go
+   straight to **Tier 3** — AI SAST can't help them.
+2. **Value score (0–1):** a tunable blend of commit **activity**
+   (`Metric` TimeTracker), high-severity **findings** count, and
+   **release/production** signal (release tags + monitored-version count).
+3. **Cost estimate:** a global blended `$/KLOC` (from observed spend ÷ scanned
+   KLOC) scaled by repo size and a monitored-version multiplier. See the
+   important cost caveats below.
+4. **Greedy allocation:** repos are ranked by **value ÷ cost** and promoted to
+   **Tier 1** until the budget (minus a safety margin) is committed; remaining
+   eligible repos with findings become **Tier 2**; the rest **Tier 3**. Tier 1
+   and Tier 2 share the one budget.
+
+## Tunable knobs (sidebar)
+
+Budget, safety margin, language-gate threshold, monitored-version multiplier
+`k`, value weights (activity / findings / release), and cost calibration
+(**multiselect the repos you've already AI-SAST scanned** — the tool sums their
+supported-language size automatically and derives `$/KLOC` from observed spend;
+no manual line-count entry). A **per-tier filter** narrows the recommendations
+table. All controls re-allocate client-side.
+
+## Export
+
+CSV (full recommendation table) and a branded PDF (estate summary, tier
+distribution, and the per-repo recommendations).
+
+## How it works
+
+One `endorctl` pull per "Generate" (repositories, monitored-version counts,
+metrics, findings, license, observed spend), cached in the browser session and
+re-allocated client-side as the knobs change.
+
+```bash
+# Reference commands the tool wraps:
+endorctl -n <ns> api list -r EndorLicense --field-mask "spec.quota.ai_limit"
+endorctl -n <ns> api list -r Repository \
+  --field-mask "meta.name,spec.languages,spec.tags,spec.default_branch" --list-all
+endorctl -n <ns> api list -r RepositoryVersion --field-mask "meta.parent_uuid" --list-all
+endorctl -n <ns> api list -r Metric --field-mask "meta.parent_uuid,spec.metric_values" --list-all
+endorctl -n <ns> api list -r Finding \
+  --filter "spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH" \
+  --field-mask "meta.parent_uuid" --list-all
+endorctl -n <ns> api list -r AICreditMetric \
+  --filter "spec.accrued_date >= <cutoff>" --field-mask "spec.llm_cost" --list-all
+```
+
+## Known limitations (important)
+
+- **Cost is coarse.** `AICreditMetric` spend is only available aggregated at
+  the **tenant/day/model** level — `ai_feature` is never populated and there is
+  **no per-repo attribution**. So the `$/KLOC` rate is a single blended,
+  tenant-wide figure scaled by size — planning-grade, not exact. Lean on the
+  safety margin. When no already-scanned repos are selected, cost falls back to
+  coarse size buckets with a low-confidence banner.
+- **Activity & findings are best-effort.** The `Metric` TimeTracker and
+  `Finding` shapes vary; parsing is defensive and defaults those components to
+  0 (flagged) rather than failing the run.
+- **Quota must be configured.** With `days == 0` / `max_credit == 0` there is
+  no budget to fit (and no usage is metered either) — the tool stops and says so.
+- **Advisory only** — assign the recommended tiers via scan profiles yourself.
+
+## Tests
+
+```bash
+pip install pytest
+pytest
+```
+
+`compute.py` holds all logic (pure, no I/O) and is fully unit-tested; all
+`endorctl`/Streamlit I/O lives in `dashboard.py`.

--- a/ai_sast_tier_recommender/README.md
+++ b/ai_sast_tier_recommender/README.md
@@ -20,8 +20,12 @@ strategy in `monorepo/doc/ai-sast-rollout-guide.md`.
 
 ```bash
 pip install -r requirements.txt
-streamlit run dashboard.py
+streamlit run dashboard.py   # serves on http://localhost:8502
 ```
+
+Runs on port **8502** (pinned in `.streamlit/config.toml`) so it can run
+alongside the spend dashboard (`../ai_credit_dashboard`, default 8501). Override
+with `streamlit run dashboard.py --server.port <port>`.
 
 In the sidebar: enter the root tenant namespace, click **Generate/Refresh**,
 then tune the allocation knobs — re-allocation is instant (client-side, no
@@ -41,8 +45,9 @@ re-fetch).
    (`Repository.spec.languages`) is below the threshold (default 50%) go
    straight to **Tier 3** — AI SAST can't help them.
 2. **Value score (0–1):** a tunable blend of commit **activity**
-   (`Metric` TimeTracker), high-severity **findings** count, and
-   **release/production** signal (release tags + monitored-version count).
+   (`Metric` TimeTracker), high-severity **SAST findings** on the default branch
+   (SCA/secrets excluded), and **release/production** signal (release tags +
+   monitored-version count).
 3. **Cost estimate:** a global blended `$/KLOC` (from observed spend ÷ scanned
    KLOC) scaled by repo size and a monitored-version multiplier. See the
    important cost caveats below.
@@ -75,12 +80,12 @@ re-allocated client-side as the knobs change.
 # Reference commands the tool wraps:
 endorctl -n <ns> api list -r EndorLicense --field-mask "spec.quota.ai_limit"
 endorctl -n <ns> api list -r Repository \
-  --field-mask "meta.name,spec.languages,spec.tags,spec.default_branch" --list-all
+  --field-mask "meta.name,meta.parent_uuid,spec.languages,spec.tags,spec.default_branch" --list-all
 endorctl -n <ns> api list -r RepositoryVersion --field-mask "meta.parent_uuid" --list-all
 endorctl -n <ns> api list -r Metric --field-mask "meta.parent_uuid,spec.metric_values" --list-all
 endorctl -n <ns> api list -r Finding \
-  --filter "spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH" \
-  --field-mask "meta.parent_uuid" --list-all
+  --filter "context.type == CONTEXT_TYPE_MAIN and (spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH) and spec.finding_categories contains [FINDING_CATEGORY_SAST]" \
+  --field-mask "spec.project_uuid" --list-all
 endorctl -n <ns> api list -r AICreditMetric \
   --filter "spec.accrued_date >= <cutoff>" --field-mask "spec.llm_cost" --list-all
 ```
@@ -93,9 +98,12 @@ endorctl -n <ns> api list -r AICreditMetric \
   tenant-wide figure scaled by size — planning-grade, not exact. Lean on the
   safety margin. When no already-scanned repos are selected, cost falls back to
   coarse size buckets with a low-confidence banner.
-- **Activity & findings are best-effort.** The `Metric` TimeTracker and
-  `Finding` shapes vary; parsing is defensive and defaults those components to
-  0 (flagged) rather than failing the run.
+- **Findings are high/critical SAST on the default branch**, joined via
+  `spec.project_uuid` (the stable key the platform uses), scoped to
+  `context.type == CONTEXT_TYPE_MAIN` so they aren't multiplied across monitored
+  release branches. SCA/secrets are excluded — AI SAST doesn't address them.
+- **Activity is best-effort.** `Metric` has a generic parent, so commit-activity
+  parsing is defensive and defaults to 0 (flagged) rather than failing the run.
 - **Quota must be configured.** With `days == 0` / `max_credit == 0` there is
   no budget to fit (and no usage is metered either) — the tool stops and says so.
 - **Advisory only** — assign the recommended tiers via scan profiles yourself.

--- a/ai_sast_tier_recommender/README.md
+++ b/ai_sast_tier_recommender/README.md
@@ -62,8 +62,11 @@ Budget, safety margin, language-gate threshold, monitored-version multiplier
 `k`, value weights (activity / findings / release), and cost calibration
 (**multiselect the repos you've already AI-SAST scanned** — the tool sums their
 supported-language size automatically and derives `$/KLOC` from observed spend;
-no manual line-count entry). A **per-tier filter** narrows the recommendations
-table. All controls re-allocate client-side.
+no manual line-count entry). An **Auto-detect scanned repos** button infers that
+selection from `RepositoryVersion.scan_object.aisast_status` (repos that were
+indexed or successfully scanned), so you rarely need to pick them by hand. A
+**per-tier filter** narrows the recommendations table. All controls re-allocate
+client-side.
 
 ## Export
 
@@ -81,7 +84,8 @@ re-allocated client-side as the knobs change.
 endorctl -n <ns> api list -r EndorLicense --field-mask "spec.quota.ai_limit"
 endorctl -n <ns> api list -r Repository \
   --field-mask "meta.name,meta.parent_uuid,spec.languages,spec.tags,spec.default_branch" --list-all
-endorctl -n <ns> api list -r RepositoryVersion --field-mask "meta.parent_uuid" --list-all
+endorctl -n <ns> api list -r RepositoryVersion \
+  --field-mask "meta.parent_uuid,scan_object.aisast_status" --list-all
 endorctl -n <ns> api list -r Metric --field-mask "meta.parent_uuid,spec.metric_values" --list-all
 endorctl -n <ns> api list -r Finding \
   --filter "context.type == CONTEXT_TYPE_MAIN and (spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH) and spec.finding_categories contains [FINDING_CATEGORY_SAST]" \

--- a/ai_sast_tier_recommender/compute.py
+++ b/ai_sast_tier_recommender/compute.py
@@ -1,0 +1,337 @@
+"""Pure computation for the AI SAST tier recommender.
+
+No Streamlit or subprocess dependencies here — keeps this module fast and
+easy to unit test in isolation. All I/O (endorctl, Streamlit) lives in
+dashboard.py; all decision logic lives here.
+
+The design is asymmetric on purpose (see the design spec, §3):
+  - VALUE signals are per-repo and high fidelity (languages, activity,
+    findings, monitored versions).
+  - COST is coarse: AICreditMetric spend is only available aggregated at the
+    tenant/day/model level (no per-feature, no per-repo attribution), so the
+    cost model is a single global $/KLOC rate scaled by repo size, with an
+    honest confidence flag.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+
+# --- Language support (mirrors codeapi.SupportedLanguages: the 12 AI SAST langs) ---
+
+SUPPORTED_LANGUAGES: frozenset[str] = frozenset(
+    {"c", "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "rust", "scala", "swift", "typescript"}
+)
+
+# Maps the many spellings ingested from SCMs (GitHub-style names, enum-ish
+# variants) onto the canonical tokens above.
+_LANGUAGE_ALIASES: dict[str, str] = {
+    "c": "c",
+    "c++": "cpp",
+    "cpp": "cpp",
+    "c#": "csharp",
+    "csharp": "csharp",
+    "cs": "csharp",
+    "go": "go",
+    "golang": "go",
+    "java": "java",
+    "javascript": "javascript",
+    "js": "javascript",
+    "node": "javascript",
+    "python": "python",
+    "py": "python",
+    "ruby": "ruby",
+    "rb": "ruby",
+    "rust": "rust",
+    "rs": "rust",
+    "scala": "scala",
+    "swift": "swift",
+    "typescript": "typescript",
+    "ts": "typescript",
+}
+
+# --- Tunable defaults (all overridable from the UI) ---
+
+LANGUAGE_GATE_THRESHOLD: float = 0.50  # min supported-language byte share for Tier 1/2 eligibility
+SAFETY_MARGIN: float = 0.20            # reserve 20% of the pool as headroom
+MONITORED_VERSION_K: float = 0.30      # each extra monitored version adds k of a baseline
+AVG_BYTES_PER_LINE: float = 30.0       # bytes -> LOC conversion for the size proxy
+PER_FINDING_TIER2_COST: float = 0.02   # heuristic $/finding for Tier-2 FP triage (NOT calibrated; see §5.4)
+
+DEFAULT_WEIGHTS: dict[str, float] = {"activity": 1 / 3, "findings": 1 / 3, "release": 1 / 3}
+
+# Size-bucket fallback ($ per repo) used when no cost calibration is available.
+SIZE_BUCKETS: list[tuple[float, float]] = [
+    (10.0, 2.0),     # <10 KLOC  -> ~$2
+    (50.0, 6.0),     # <50 KLOC  -> ~$6
+    (200.0, 20.0),   # <200 KLOC -> ~$20
+]
+SIZE_BUCKET_LARGE_COST: float = 50.0   # >= largest threshold
+
+
+def normalize_language(name: str) -> Optional[str]:
+    """Canonical supported-language token for an ingested language name, or None if unsupported."""
+    token = _LANGUAGE_ALIASES.get(name.strip().lower())
+    return token if token in SUPPORTED_LANGUAGES else None
+
+
+def short_repo_name(name: str) -> str:
+    """Last path segment of a repo URL/name, without a trailing '.git' (for legible display).
+
+    'https://github.com/acacceptance-platform/pr-agent-settings.git' -> 'pr-agent-settings'.
+    Falls back to the original string if there's nothing to trim.
+    """
+    if not name:
+        return name
+    segment = name.rstrip("/").rsplit("/", 1)[-1]
+    if segment.endswith(".git"):
+        segment = segment[:-4]
+    return segment or name
+
+
+def supported_language_share(languages: dict[str, float]) -> float:
+    """Fraction of bytes written in AI-SAST-supported languages. 0.0 for an empty/None map."""
+    if not languages:
+        return 0.0
+    total = 0.0
+    supported = 0.0
+    for name, byte_count in languages.items():
+        b = float(byte_count or 0)
+        total += b
+        if normalize_language(name) is not None:
+            supported += b
+    if total <= 0:
+        return 0.0
+    return supported / total
+
+
+def passes_language_gate(share: float, threshold: float = LANGUAGE_GATE_THRESHOLD) -> bool:
+    """True when a repo has enough supported-language code to make AI SAST worthwhile."""
+    return share >= threshold
+
+
+def supported_kloc(languages: dict[str, float], bytes_per_line: float = AVG_BYTES_PER_LINE) -> float:
+    """Approximate thousands-of-lines-of-code in supported languages (size/cost proxy)."""
+    if not languages or bytes_per_line <= 0:
+        return 0.0
+    supported_bytes = sum(
+        float(b or 0) for name, b in languages.items() if normalize_language(name) is not None
+    )
+    return supported_bytes / bytes_per_line / 1000.0
+
+
+def total_supported_kloc(languages_maps: list[dict[str, float]]) -> float:
+    """Combined supported-language KLOC across a set of repos (their language maps).
+
+    Used to derive the calibration denominator from the repos a CSE has already
+    baselined — no manual KLOC entry needed, since repo sizes come from the
+    language data the tool already fetched.
+    """
+    return sum(supported_kloc(m) for m in languages_maps)
+
+
+def calibrate_cost_per_kloc(total_spend: float, total_scanned_kloc: float) -> tuple[Optional[float], str]:
+    """Global blended $/KLOC from observed spend, with a confidence label.
+
+    Returns (rate, confidence). rate is None when there is no calibration data,
+    in which case callers must fall back to size buckets. Confidence is coarse
+    because spend is only a tenant-wide aggregate (see spec §3):
+      - "none":   no scanned KLOC yet -> use size buckets.
+      - "low":    some data but a small sample.
+      - "medium": a more substantial sample.
+    """
+    if total_scanned_kloc <= 0 or total_spend <= 0:
+        return None, "none"
+    rate = total_spend / total_scanned_kloc
+    confidence = "medium" if total_scanned_kloc >= 100 else "low"
+    return rate, confidence
+
+
+def monitored_version_multiplier(monitored_versions: int, k: float = MONITORED_VERSION_K) -> float:
+    """Cost multiplier for extra monitored branches: 1 + k*(n-1), floored at 1.0."""
+    n = max(1, int(monitored_versions or 1))
+    return 1.0 + k * (n - 1)
+
+
+def size_bucket_cost(kloc: float) -> float:
+    """Fixed per-repo cost estimate when no calibration exists."""
+    for threshold, cost in SIZE_BUCKETS:
+        if kloc < threshold:
+            return cost
+    return SIZE_BUCKET_LARGE_COST
+
+
+def estimate_tier1_cost(
+    kloc: float,
+    rate: Optional[float],
+    monitored_versions: int,
+    k: float = MONITORED_VERSION_K,
+) -> float:
+    """Estimated first-window Tier-1 credit cost (the onboarding-baseline worst case).
+
+    Uses the calibrated $/KLOC rate when available, else the size-bucket fallback,
+    then scales by the monitored-version multiplier.
+    """
+    base = size_bucket_cost(kloc) if rate is None else kloc * rate
+    return base * monitored_version_multiplier(monitored_versions, k)
+
+
+def estimate_tier2_cost(finding_count: int, per_finding: float = PER_FINDING_TIER2_COST) -> float:
+    """Heuristic Tier-2 (FP-triage) cost. NOT calibrated from observed spend (spec §5.4)."""
+    return max(0, int(finding_count or 0)) * per_finding
+
+
+def normalize_series(values: pd.Series) -> pd.Series:
+    """Min-max normalize to 0..1. All-equal (incl. all-zero) series -> all zeros."""
+    if values.empty:
+        return values
+    lo = float(values.min())
+    hi = float(values.max())
+    if hi <= lo:
+        return pd.Series([0.0] * len(values), index=values.index)
+    return (values - lo) / (hi - lo)
+
+
+def value_score(components: dict[str, float], weights: dict[str, float] = DEFAULT_WEIGHTS) -> float:
+    """Weighted blend of normalized value components (activity, findings, release)."""
+    total_weight = sum(weights.values())
+    if total_weight <= 0:
+        return 0.0
+    score = sum(components.get(name, 0.0) * w for name, w in weights.items())
+    return score / total_weight
+
+
+@dataclass
+class AllocationParams:
+    """Knobs for a single allocation run (all UI-tunable)."""
+
+    budget: float
+    safety_margin: float = SAFETY_MARGIN
+    weights: dict[str, float] = field(default_factory=lambda: dict(DEFAULT_WEIGHTS))
+    gate_threshold: float = LANGUAGE_GATE_THRESHOLD
+    monitored_version_k: float = MONITORED_VERSION_K
+    cost_rate: Optional[float] = None  # calibrated $/KLOC, or None for size buckets
+
+
+def allocate_tiers(repos: pd.DataFrame, params: AllocationParams) -> pd.DataFrame:
+    """Assign a tier to every repo via greedy value-density packing under budget.
+
+    Expected input columns (one row per project):
+      project, languages (dict lang->bytes), monitored_versions (int),
+      activity (float, raw), findings (int, target-class/high-sev count),
+      release_signal (float, raw e.g. tag count).
+
+    Output adds columns:
+      supported_share, kloc, value, est_cost, vc_ratio, tier (1/2/3),
+      rank (Tier-1 promotion order or NaN), rationale.
+    """
+    out_cols = [
+        "supported_share", "kloc", "value", "est_cost", "vc_ratio", "tier", "rank", "rationale",
+    ]
+    if repos.empty:
+        return repos.assign(**{c: pd.Series(dtype="float") for c in out_cols})
+
+    df = repos.copy().reset_index(drop=True)
+
+    df["supported_share"] = df["languages"].apply(supported_language_share)
+    df["kloc"] = df["languages"].apply(lambda m: supported_kloc(m))
+    df["eligible"] = df["supported_share"].apply(lambda s: passes_language_gate(s, params.gate_threshold))
+
+    # Normalize value components across the eligible population.
+    eligible_mask = df["eligible"]
+    for raw, norm in (("activity", "n_activity"), ("findings", "n_findings"), ("release_signal", "n_release")):
+        col = pd.to_numeric(df.get(raw, 0), errors="coerce").fillna(0.0)
+        normed = pd.Series(0.0, index=df.index)
+        if eligible_mask.any():
+            normed.loc[eligible_mask] = normalize_series(col[eligible_mask])
+        df[norm] = normed
+
+    df["value"] = df.apply(
+        lambda r: value_score(
+            {"activity": r["n_activity"], "findings": r["n_findings"], "release": r["n_release"]},
+            params.weights,
+        ),
+        axis=1,
+    )
+    df["est_cost"] = df.apply(
+        lambda r: estimate_tier1_cost(r["kloc"], params.cost_rate, r["monitored_versions"], params.monitored_version_k),
+        axis=1,
+    )
+    df["vc_ratio"] = df.apply(
+        lambda r: (r["value"] / r["est_cost"]) if r["est_cost"] > 0 else 0.0, axis=1
+    )
+
+    df["tier"] = 3
+    df["rank"] = pd.NA
+    df["rationale"] = ""
+
+    # Language-gated repos are Tier 3 regardless of value.
+    df.loc[~df["eligible"], "rationale"] = df.loc[~df["eligible"], "supported_share"].apply(
+        lambda s: f"Tier 3: only {s * 100:.0f}% supported-language code (gate {params.gate_threshold * 100:.0f}%)."
+    )
+
+    budget_cap = params.budget * (1.0 - params.safety_margin)
+    committed = 0.0
+
+    eligible = df[df["eligible"]].sort_values("vc_ratio", ascending=False)
+
+    # Pass 1: promote to Tier 1 by value-density until the (margin-adjusted) budget is committed.
+    rank = 0
+    for idx in eligible.index:
+        cost = df.at[idx, "est_cost"]
+        if committed + cost <= budget_cap:
+            rank += 1
+            committed += cost
+            df.at[idx, "tier"] = 1
+            df.at[idx, "rank"] = rank
+            df.at[idx, "rationale"] = (
+                f"Tier 1: V/C rank #{rank}, est ${cost:.2f} first-window "
+                f"(committed ${committed:.2f} / ${budget_cap:.2f} usable)."
+            )
+
+    # Pass 2: remaining eligible repos with findings get Tier 2 while budget remains.
+    for idx in eligible.index:
+        if df.at[idx, "tier"] == 1:
+            continue
+        findings = int(pd.to_numeric(df.at[idx, "findings"], errors="coerce") or 0)
+        if findings <= 0:
+            df.at[idx, "rationale"] = "Tier 3: eligible but no findings to triage."
+            continue
+        t2 = estimate_tier2_cost(findings)
+        if committed + t2 <= budget_cap:
+            committed += t2
+            df.at[idx, "tier"] = 2
+            df.at[idx, "rationale"] = f"Tier 2: rule-based + FP triage, est ${t2:.2f} (heuristic)."
+        else:
+            df.at[idx, "rationale"] = "Tier 3: budget exhausted before promotion."
+
+    return df.drop(columns=["eligible", "n_activity", "n_findings", "n_release"])
+
+
+def allocation_summary(allocated: pd.DataFrame, params: AllocationParams) -> dict[str, float]:
+    """Estate roll-up: per-tier counts, projected spend, and headroom vs budget."""
+    if allocated.empty:
+        return {
+            "tier1_count": 0, "tier2_count": 0, "tier3_count": 0,
+            "projected_spend": 0.0, "budget": params.budget,
+            "usable_budget": params.budget * (1 - params.safety_margin),
+            "headroom": params.budget * (1 - params.safety_margin),
+        }
+    tier1 = allocated[allocated["tier"] == 1]
+    tier2 = allocated[allocated["tier"] == 2]
+    projected = float(tier1["est_cost"].sum()) + float(
+        tier2["findings"].apply(lambda f: estimate_tier2_cost(int(f or 0))).sum()
+    )
+    usable = params.budget * (1 - params.safety_margin)
+    return {
+        "tier1_count": int(len(tier1)),
+        "tier2_count": int(len(tier2)),
+        "tier3_count": int((allocated["tier"] == 3).sum()),
+        "projected_spend": projected,
+        "budget": params.budget,
+        "usable_budget": usable,
+        "headroom": usable - projected,
+    }

--- a/ai_sast_tier_recommender/compute.py
+++ b/ai_sast_tier_recommender/compute.py
@@ -78,6 +78,17 @@ def normalize_language(name: str) -> Optional[str]:
     return token if token in SUPPORTED_LANGUAGES else None
 
 
+def root_namespace(namespace: str) -> str:
+    """Tenant root (first path segment) of a namespace.
+
+    AICreditMetric is a root-only, non-local resource — it's written and read at
+    'namespace.Root(...)' and never surfaces from a child/app namespace via
+    traversal. Spend calibration must therefore query the root, not the child.
+    'american-credit-acceptance.acacceptance-appdev' -> 'american-credit-acceptance'.
+    """
+    return namespace.split(".")[0] if namespace else namespace
+
+
 def short_repo_name(name: str) -> str:
     """Last path segment of a repo URL/name, without a trailing '.git' (for legible display).
 

--- a/ai_sast_tier_recommender/compute.py
+++ b/ai_sast_tier_recommender/compute.py
@@ -84,7 +84,7 @@ def root_namespace(namespace: str) -> str:
     AICreditMetric is a root-only, non-local resource — it's written and read at
     'namespace.Root(...)' and never surfaces from a child/app namespace via
     traversal. Spend calibration must therefore query the root, not the child.
-    'american-credit-acceptance.acacceptance-appdev' -> 'american-credit-acceptance'.
+    'acme-corp.acme-appdev' -> 'acme-corp'.
     """
     return namespace.split(".")[0] if namespace else namespace
 
@@ -92,7 +92,7 @@ def root_namespace(namespace: str) -> str:
 def short_repo_name(name: str) -> str:
     """Last path segment of a repo URL/name, without a trailing '.git' (for legible display).
 
-    'https://github.com/acacceptance-platform/pr-agent-settings.git' -> 'pr-agent-settings'.
+    'https://github.com/acme-platform/pr-agent-settings.git' -> 'pr-agent-settings'.
     Falls back to the original string if there's nothing to trim.
     """
     if not name:
@@ -159,6 +159,39 @@ def calibrate_cost_per_kloc(total_spend: float, total_scanned_kloc: float) -> tu
     rate = total_spend / total_scanned_kloc
     confidence = "medium" if total_scanned_kloc >= 100 else "low"
     return rate, confidence
+
+
+def monitored_version_counts(versions: list[dict]) -> dict[str, int]:
+    """Monitored-version count per parent Project uuid, from RepositoryVersion objects."""
+    counts: dict[str, int] = {}
+    for obj in versions:
+        parent = (obj.get("meta") or {}).get("parent_uuid")
+        if parent:
+            counts[parent] = counts.get(parent, 0) + 1
+    return counts
+
+
+def ai_sast_scanned_projects(versions: list[dict]) -> set[str]:
+    """Parent Project uuids that already have an AI-SAST-indexed or -scanned version.
+
+    Reads RepositoryVersion.scan_object.aisast_status: a version qualifies if it was
+    indexed (last_full_index_time / last_full_index_sha set) or has a completed scan
+    (last_scan_state == AISAST_SCAN_STATE_SCAN_SUCCEEDED). Either means AI SAST credits
+    were spent, which is exactly what makes the repo a valid cost-calibration sample.
+    """
+    scanned: set[str] = set()
+    for obj in versions:
+        parent = (obj.get("meta") or {}).get("parent_uuid")
+        if not parent:
+            continue
+        status = (obj.get("scan_object") or {}).get("aisast_status") or {}
+        if (
+            status.get("last_full_index_time")
+            or status.get("last_full_index_sha")
+            or status.get("last_scan_state") == "AISAST_SCAN_STATE_SCAN_SUCCEEDED"
+        ):
+            scanned.add(parent)
+    return scanned
 
 
 def monitored_version_multiplier(monitored_versions: int, k: float = MONITORED_VERSION_K) -> float:

--- a/ai_sast_tier_recommender/dashboard.py
+++ b/ai_sast_tier_recommender/dashboard.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""
+AI SAST Tier Recommender - Streamlit app.
+
+Given a namespace, recommends a tier (1/2/3) per repository that maximizes
+security value while fitting the tenant's AI credit budget, with an
+explainable rationale per repo. Advisory only — never applies scan profiles
+or changes quota.
+
+Mirrors the ai_credit_dashboard pattern: pure logic in compute.py, all I/O
+here, one endorctl pull per "Generate" cached in session_state, then
+re-allocation happens client-side as the sidebar knobs change.
+"""
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import streamlit as st
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from reportlab.lib.pagesizes import letter, landscape
+from reportlab.lib.units import inch
+from reportlab.lib.colors import HexColor
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image as RLImage, Table, TableStyle
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+
+import compute
+from compute import AllocationParams
+
+
+# --- endorctl I/O (same wrapper as the spend dashboard) ---
+
+def run_endorctl(args: List[str], namespace: str, timeout: int = 300) -> Optional[Dict[str, Any]]:
+    """Execute an endorctl command and return parsed JSON."""
+    cmd = ["endorctl", "-n", namespace] + args
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=timeout)
+        if result.stdout.strip():
+            return json.loads(result.stdout)
+        return None
+    except subprocess.CalledProcessError as e:
+        st.error(f"endorctl error: {e.stderr}")
+        return None
+    except subprocess.TimeoutExpired:
+        st.error(f"Command timed out: {' '.join(cmd)}")
+        return None
+    except json.JSONDecodeError as e:
+        st.error(f"JSON parse error: {e}")
+        return None
+
+
+def _objects(response: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not response:
+        return []
+    return response.get("list", {}).get("objects", [])
+
+
+def fetch_license(namespace: str) -> Optional[Dict[str, float]]:
+    """Fetch the tenant's AI credit quota: {'days': int, 'max_credit': float}. None if unavailable."""
+    response = run_endorctl(
+        ["api", "list", "-r", "EndorLicense", "--field-mask", "spec.quota.ai_limit"], namespace
+    )
+    objects = _objects(response)
+    if not objects:
+        return None
+    ai_limit = objects[0].get("spec", {}).get("quota", {}).get("ai_limit", {})
+    days = ai_limit.get("days")
+    max_credit = ai_limit.get("max_credit")
+    if days is None or max_credit is None:
+        return None
+    return {"days": int(days), "max_credit": float(max_credit)}
+
+
+def fetch_total_ai_spend(namespace: str, days: int = 180) -> float:
+    """Sum of observed AICreditMetric llm_cost over the trailing window (calibration numerator)."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    response = run_endorctl(
+        [
+            "api", "list", "-r", "AICreditMetric",
+            "--filter", f"spec.accrued_date >= {cutoff}",
+            "--field-mask", "spec.llm_cost", "--list-all",
+        ],
+        namespace,
+    )
+    return sum(float(o.get("spec", {}).get("llm_cost", 0.0) or 0.0) for o in _objects(response))
+
+
+def _parse_languages(languages_field: Any) -> Dict[str, float]:
+    """Best-effort extraction of a {language_name: bytes} map from Repository.spec.languages.
+
+    The field wraps a raw ingested object whose exact shape varies by SCM; we
+    defensively pull out the first nested {str: number} mapping we find.
+    """
+    def find_map(node: Any) -> Dict[str, float]:
+        if isinstance(node, dict):
+            numeric = {k: float(v) for k, v in node.items() if isinstance(v, (int, float)) and not isinstance(v, bool)}
+            if numeric:
+                return numeric
+            for v in node.values():
+                found = find_map(v)
+                if found:
+                    return found
+        return {}
+
+    return find_map(languages_field)
+
+
+def fetch_repositories(namespace: str) -> pd.DataFrame:
+    """One row per repository: uuid, project (name), languages (dict), release_signal (tag count)."""
+    response = run_endorctl(
+        [
+            "api", "list", "-r", "Repository",
+            "--field-mask", "meta.name,spec.languages,spec.tags,spec.default_branch",
+            "--list-all",
+        ],
+        namespace,
+    )
+    rows = []
+    for obj in _objects(response):
+        spec = obj.get("spec", {})
+        rows.append({
+            "uuid": obj.get("uuid"),
+            "project": obj.get("meta", {}).get("name", "unknown"),
+            "languages": _parse_languages(spec.get("languages")),
+            "release_signal": float(len(spec.get("tags") or [])),
+        })
+    return pd.DataFrame(rows, columns=["uuid", "project", "languages", "release_signal"])
+
+
+def fetch_monitored_version_counts(namespace: str) -> Dict[str, int]:
+    """Count of monitored RepositoryVersions per repository uuid (meta.parent_uuid)."""
+    response = run_endorctl(
+        ["api", "list", "-r", "RepositoryVersion", "--field-mask", "meta.parent_uuid", "--list-all"],
+        namespace,
+    )
+    counts: Dict[str, int] = {}
+    for obj in _objects(response):
+        parent = obj.get("meta", {}).get("parent_uuid")
+        if parent:
+            counts[parent] = counts.get(parent, 0) + 1
+    return counts
+
+
+def fetch_activity(namespace: str) -> Dict[str, float]:
+    """Best-effort recent commit activity per repository uuid, from Metric TimeTracker slots.
+
+    Returns {} if metrics can't be read; the activity component then scores 0 (flagged in the UI).
+    """
+    try:
+        response = run_endorctl(
+            ["api", "list", "-r", "Metric", "--field-mask", "meta.parent_uuid,spec.metric_values", "--list-all"],
+            namespace,
+        )
+    except Exception:
+        return {}
+
+    activity: Dict[str, float] = {}
+    for obj in _objects(response):
+        parent = obj.get("meta", {}).get("parent_uuid")
+        if not parent:
+            continue
+        tracker = _find_time_tracker(obj.get("spec", {}))
+        if tracker is None:
+            continue
+        slots = tracker.get("monthly_activity") or tracker.get("daily_activity") or []
+        recent = sum(float(s.get("count", 0) or 0) for s in slots[-3:])
+        if recent:
+            activity[parent] = activity.get(parent, 0.0) + recent
+    return activity
+
+
+def _find_time_tracker(node: Any) -> Optional[Dict[str, Any]]:
+    """Locate a TimeTracker-shaped dict (has *_activity slot lists) anywhere in a metric spec."""
+    if isinstance(node, dict):
+        if any(k in node for k in ("daily_activity", "monthly_activity", "yearly_activity")):
+            return node
+        for v in node.values():
+            found = _find_time_tracker(v)
+            if found:
+                return found
+    elif isinstance(node, list):
+        for v in node:
+            found = _find_time_tracker(v)
+            if found:
+                return found
+    return None
+
+
+def fetch_finding_counts(namespace: str) -> Dict[str, int]:
+    """Best-effort count of high-severity findings per repository uuid.
+
+    Findings taxonomy varies; this is intentionally coarse and defaults to
+    empty (so the findings component scores 0) rather than failing the run.
+    """
+    try:
+        response = run_endorctl(
+            [
+                "api", "list", "-r", "Finding",
+                "--filter", "spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH",
+                "--field-mask", "meta.parent_uuid", "--list-all",
+            ],
+            namespace,
+        )
+    except Exception:
+        return {}
+
+    counts: Dict[str, int] = {}
+    for obj in _objects(response):
+        parent = obj.get("meta", {}).get("parent_uuid")
+        if parent:
+            counts[parent] = counts.get(parent, 0) + 1
+    return counts
+
+
+def assemble_repos(namespace: str) -> pd.DataFrame:
+    """Fetch and join all per-repo signals into the allocator's input frame."""
+    repos = fetch_repositories(namespace)
+    if repos.empty:
+        return repos.assign(monitored_versions=pd.Series(dtype="int"),
+                            activity=pd.Series(dtype="float"), findings=pd.Series(dtype="int"))
+    mv = fetch_monitored_version_counts(namespace)
+    activity = fetch_activity(namespace)
+    findings = fetch_finding_counts(namespace)
+
+    repos["monitored_versions"] = repos["uuid"].map(lambda u: mv.get(u, 1)).fillna(1).astype(int)
+    repos["activity"] = repos["uuid"].map(lambda u: activity.get(u, 0.0)).fillna(0.0)
+    repos["findings"] = repos["uuid"].map(lambda u: findings.get(u, 0)).fillna(0).astype(int)
+    return repos
+
+
+# --- Presentation ---
+
+BRAND = {
+    "green": "#00D26A", "dark": "#1A1A2E", "tier1": "#00D26A", "tier2": "#fbc02d",
+    "tier3": "#5A6577", "text_primary": "#1A1A2E", "text_secondary": "#5A6577",
+    "white": "#FFFFFF", "table_header_bg": "#1A1A2E", "table_header_text": "#FFFFFF",
+    "table_row_alt": "#F8F9FA", "table_border": "#DEE2E6",
+}
+
+TIER_LABELS = {1: "Tier 1 (AI SAST agent)", 2: "Tier 2 (rules + FP triage)", 3: "Tier 3 (rules only)"}
+
+
+def _display_frame(allocated: pd.DataFrame) -> pd.DataFrame:
+    """Human-readable columns for the recommendation table and exports."""
+    cols = ["project", "tier", "rank", "value", "est_cost", "vc_ratio",
+            "supported_share", "monitored_versions", "findings", "rationale"]
+    df = allocated[[c for c in cols if c in allocated.columns]].copy()
+    df = df.sort_values(["tier", "rank", "value"], ascending=[True, True, False], na_position="last")
+    df["project"] = df["project"].map(compute.short_repo_name)
+    df["tier"] = df["tier"].map(lambda t: TIER_LABELS.get(int(t), str(t)))
+    df["supported_share"] = (df["supported_share"] * 100).round(0)
+    df["value"] = df["value"].round(3)
+    df["est_cost"] = df["est_cost"].round(2)
+    df["vc_ratio"] = df["vc_ratio"].round(4)
+    return df.rename(columns={
+        "project": "Repository", "tier": "Tier", "rank": "T1 Rank", "value": "Value",
+        "est_cost": "Est. Cost ($)", "vc_ratio": "Value/Cost", "supported_share": "Supported %",
+        "monitored_versions": "Monitored Vers.", "findings": "High-sev Findings", "rationale": "Rationale",
+    })
+
+
+def _fig_to_rl_image(fig, width: float, height: float) -> RLImage:
+    buf = BytesIO()
+    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight", facecolor=fig.get_facecolor(), edgecolor="none")
+    plt.close(fig)
+    buf.seek(0)
+    return RLImage(buf, width=width, height=height)
+
+
+def _tier_distribution_chart(summary: Dict[str, float], page_width: float) -> RLImage:
+    fig, ax = plt.subplots(figsize=(page_width / 72, 2.2))
+    fig.set_facecolor(BRAND["white"])
+    ax.set_facecolor(BRAND["white"])
+    tiers = ["Tier 1", "Tier 2", "Tier 3"]
+    counts = [summary["tier1_count"], summary["tier2_count"], summary["tier3_count"]]
+    ax.bar(tiers, counts, color=[BRAND["tier1"], BRAND["tier2"], BRAND["tier3"]], edgecolor="none")
+    ax.set_ylabel("Repositories", fontsize=9, color=BRAND["text_secondary"])
+    ax.grid(axis="y", linestyle="-", alpha=0.15, color="#AAAAAA")
+    for spine in ("top", "right"):
+        ax.spines[spine].set_visible(False)
+    ax.tick_params(colors=BRAND["text_secondary"], labelsize=9)
+    fig.tight_layout()
+    return _fig_to_rl_image(fig, page_width, 2.2 * 72)
+
+
+def generate_pdf(namespace: str, summary: Dict[str, float], display_df: pd.DataFrame,
+                  confidence: str, params: AllocationParams) -> bytes:
+    buf = BytesIO()
+    page_w, _ = landscape(letter)
+    margin = 0.6 * inch
+    doc = SimpleDocTemplate(buf, pagesize=landscape(letter), leftMargin=margin,
+                            rightMargin=margin, topMargin=margin, bottomMargin=margin)
+    usable_width = page_w - 2 * margin
+
+    styles = getSampleStyleSheet()
+    styles.add(ParagraphStyle("Title2", parent=styles["Title"], fontSize=20, textColor=HexColor(BRAND["dark"]), spaceAfter=4))
+    styles.add(ParagraphStyle("Subtitle", parent=styles["Normal"], fontSize=10, textColor=HexColor(BRAND["text_secondary"]), spaceAfter=12))
+    styles.add(ParagraphStyle("SectionHeader", parent=styles["Heading2"], fontSize=13, textColor=HexColor(BRAND["dark"]), spaceBefore=14, spaceAfter=8))
+
+    elements = [Paragraph("AI SAST Tier Recommendations", styles["Title2"])]
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    elements.append(Paragraph(
+        f"Namespace: {namespace}  |  Budget: ${params.budget:.2f}  |  Safety margin: {params.safety_margin * 100:.0f}%  |  "
+        f"Cost confidence: {confidence}  |  Generated: {ts}",
+        styles["Subtitle"],
+    ))
+    divider = Table([[""]], colWidths=[usable_width], rowHeights=[3])
+    divider.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["green"]))]))
+    elements.append(divider)
+    elements.append(Spacer(1, 12))
+
+    summary_data = [
+        ["Tier 1", "Tier 2", "Tier 3", "Projected Spend", "Usable Budget", "Headroom"],
+        [str(summary["tier1_count"]), str(summary["tier2_count"]), str(summary["tier3_count"]),
+         f"${summary['projected_spend']:.2f}", f"${summary['usable_budget']:.2f}", f"${summary['headroom']:.2f}"],
+    ]
+    col_w = usable_width / 6
+    summary_table = Table(summary_data, colWidths=[col_w] * 6, rowHeights=[20, 30])
+    summary_table.setStyle(TableStyle([
+        ("ALIGN", (0, 0), (-1, -1), "CENTER"), ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("FONTSIZE", (0, 0), (-1, 0), 9), ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["text_secondary"])),
+        ("FONTNAME", (0, 1), (-1, 1), "Helvetica-Bold"), ("FONTSIZE", (0, 1), (-1, 1), 13),
+        ("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["table_row_alt"])),
+        ("BOX", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+    ]))
+    elements.append(summary_table)
+    elements.append(Spacer(1, 12))
+
+    elements.append(Paragraph("Tier Distribution", styles["SectionHeader"]))
+    elements.append(_tier_distribution_chart(summary, usable_width))
+    elements.append(Spacer(1, 8))
+
+    elements.append(Paragraph("Recommendations", styles["SectionHeader"]))
+    show = display_df.drop(columns=["Rationale"], errors="ignore")
+    table_rows = [list(show.columns)] + show.astype(str).values.tolist()
+    n = len(show.columns)
+    rec_table = Table(table_rows, colWidths=[usable_width / n] * n, repeatRows=1)
+    rec_table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), HexColor(BRAND["table_header_bg"])),
+        ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["table_header_text"])),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 7), ("ALIGN", (1, 0), (-1, -1), "CENTER"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"), ("GRID", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [HexColor(BRAND["white"]), HexColor(BRAND["table_row_alt"])]),
+    ]))
+    elements.append(rec_table)
+
+    doc.build(elements)
+    return buf.getvalue()
+
+
+def main():
+    st.set_page_config(page_title="AI SAST Tier Recommender", page_icon="\U0001F6E1",
+                       layout="wide", initial_sidebar_state="expanded")
+
+    for key in ("repos_df", "license_info", "namespace", "total_spend"):
+        st.session_state.setdefault(key, None)
+
+    st.title("AI SAST Tier Recommender")
+    st.markdown(
+        "Recommends a tier per repository that maximizes security value while fitting the tenant's "
+        "AI credit budget. **Advisory only** — it never applies scan profiles or changes quota."
+    )
+    st.markdown("---")
+
+    with st.sidebar:
+        st.header("Configuration")
+        try:
+            subprocess.run(["endorctl", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            st.success("endorctl available")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            st.error("endorctl not found in PATH")
+            st.stop()
+
+        namespace = st.text_input("Namespace", value="", help="Root tenant namespace to query")
+        generate = st.button("Generate/Refresh", type="primary", use_container_width=True)
+
+    if generate:
+        if not namespace:
+            st.error("Please enter a namespace.")
+            st.stop()
+        with st.spinner("Fetching license quota..."):
+            license_info = fetch_license(namespace)
+        if not license_info:
+            st.error("Could not read AI credit quota (EndorLicense.spec.quota.ai_limit) for this namespace.")
+            st.stop()
+        with st.spinner("Fetching repositories and signals (this can take a minute)..."):
+            repos_df = assemble_repos(namespace)
+            total_spend = fetch_total_ai_spend(namespace)
+        st.session_state.repos_df = repos_df
+        st.session_state.license_info = license_info
+        st.session_state.namespace = namespace
+        st.session_state.total_spend = total_spend
+        st.rerun()
+
+    if st.session_state.license_info is None:
+        st.info("Configure the namespace in the sidebar and click **Generate/Refresh**.")
+        st.stop()
+
+    license_info = st.session_state.license_info
+    repos_df = st.session_state.repos_df
+    namespace = st.session_state.namespace
+    total_spend = st.session_state.total_spend or 0.0
+
+    if repos_df is None or repos_df.empty:
+        st.warning("No repositories found in this namespace.")
+        st.stop()
+
+    if license_info["days"] == 0 or license_info["max_credit"] <= 0:
+        st.error(
+            "AI credit quota is not configured (`days == 0` or `max_credit == 0`). "
+            "Budget-aware allocation needs a real quota — set it via a service request first. "
+            "Note: with no quota configured, no usage is ever metered either."
+        )
+        st.stop()
+
+    # --- Tunable knobs (re-allocation is client-side; no re-fetch) ---
+    with st.sidebar:
+        st.markdown("---")
+        st.subheader("Allocation knobs")
+        budget = st.number_input(
+            "Budget (credits = $)", min_value=0.0, value=float(license_info["max_credit"]), step=10.0,
+            help="Total AI credit pool to allocate against (1 credit = US$1 of LLM spend). Defaults to the "
+                 "license's max_credit; override it for what-if planning.",
+        )
+        safety_margin = st.slider(
+            "Safety margin", 0.0, 0.5, compute.SAFETY_MARGIN, 0.05,
+            help="Fraction of the budget held back as headroom. Tier 1 promotion stops once committed cost "
+                 "reaches budget × (1 − margin), so estimation error doesn't blow the pool.",
+        )
+        gate_threshold = st.slider(
+            "Language gate (supported byte share)", 0.0, 1.0, compute.LANGUAGE_GATE_THRESHOLD, 0.05,
+            help="Minimum share of a repo's code (by bytes) written in AI-SAST-supported languages to be "
+                 "eligible for Tier 1/2. Below this a repo goes straight to Tier 3 — AI SAST can't help it.",
+        )
+        mv_k = st.slider(
+            "Monitored-version cost multiplier (k)", 0.0, 1.0, compute.MONITORED_VERSION_K, 0.05,
+            help="How much each extra monitored branch adds to a repo's estimated cost: "
+                 "multiplier = 1 + k × (monitored versions − 1). Release branches are scanned too, so more "
+                 "monitored versions cost more.",
+        )
+        st.caption("Value weights (auto-normalized)")
+        w_activity = st.slider(
+            "Activity", 0.0, 1.0, compute.DEFAULT_WEIGHTS["activity"], 0.05,
+            help="Weight of commit activity (from Metric history) in the value score. Active repos rank higher. "
+                 "Weights are normalized, so only their ratios matter.",
+        )
+        w_findings = st.slider(
+            "Findings", 0.0, 1.0, compute.DEFAULT_WEIGHTS["findings"], 0.05,
+            help="Weight of high-severity finding density in the value score — where AI SAST's exploitability "
+                 "reasoning pays off most. Weights are normalized, so only their ratios matter.",
+        )
+        w_release = st.slider(
+            "Release/prod", 0.0, 1.0, compute.DEFAULT_WEIGHTS["release"], 0.05,
+            help="Weight of the production signal (release tags + monitored-version count) in the value score. "
+                 "Weights are normalized, so only their ratios matter.",
+        )
+        st.markdown("---")
+        st.subheader("Cost calibration")
+        st.caption(f"Observed AI spend (trailing 180d): ${total_spend:.2f}")
+        scanned_repos = st.multiselect(
+            "Calibrate cost from already-scanned repos",
+            options=sorted(repos_df["project"].tolist()),
+            default=[],
+            format_func=compute.short_repo_name,
+            help=(
+                "Pick the repos you've already AI-SAST baselined. The tool sums their "
+                "supported-language size (KLOC) and divides your observed AI spend by it to get a "
+                "blended **$/KLOC** rate.\n\n"
+                "That rate sets the **Est. Cost** for every repo, which drives **Projected Spend**, "
+                "**Headroom**, and which repos get promoted to Tier 1 (allocation is budget-aware).\n\n"
+                "Because AICreditMetric spend isn't attributable per repo, it's one tenant-wide rate — "
+                "planning-grade, not exact. Select nothing to fall back to coarse size buckets."
+            ),
+        )
+        scanned_langs = repos_df[repos_df["project"].isin(scanned_repos)]["languages"].tolist()
+        scanned_kloc = compute.total_supported_kloc(scanned_langs)
+        if scanned_repos:
+            st.caption(f"Selected: {len(scanned_repos)} repos ≈ {scanned_kloc:,.0f} KLOC supported-language code")
+
+    rate, confidence = compute.calibrate_cost_per_kloc(total_spend, scanned_kloc)
+
+    params = AllocationParams(
+        budget=budget, safety_margin=safety_margin,
+        weights={"activity": w_activity, "findings": w_findings, "release": w_release},
+        gate_threshold=gate_threshold, monitored_version_k=mv_k, cost_rate=rate,
+    )
+
+    allocated = compute.allocate_tiers(repos_df, params)
+    summary = compute.allocation_summary(allocated, params)
+
+    # --- Summary ---
+    st.markdown("## Estate Summary")
+    if confidence == "none":
+        st.warning(
+            "**Cost is uncalibrated** — no scanned-KLOC entered, so estimates use coarse size buckets. "
+            "Enter KLOC already scanned in the sidebar (and rely on the safety margin) for a real fit."
+        )
+    else:
+        st.info(f"Cost calibration: **{confidence}** confidence (${rate:.4f}/KLOC blended, tenant-wide — not per-feature or per-repo).")
+
+    c1, c2, c3, c4, c5, c6 = st.columns(6)
+    c1.metric("Tier 1", summary["tier1_count"])
+    c2.metric("Tier 2", summary["tier2_count"])
+    c3.metric("Tier 3", summary["tier3_count"])
+    c4.metric("Projected Spend", f"${summary['projected_spend']:.2f}")
+    c5.metric("Usable Budget", f"${summary['usable_budget']:.2f}")
+    c6.metric("Headroom", f"${summary['headroom']:.2f}")
+
+    if summary["headroom"] < 0:
+        st.error("Projected spend exceeds the usable budget — tighten the gate, lower weights, or raise the budget.")
+
+    st.markdown("## Recommendations")
+    tier_filter = st.selectbox(
+        "Filter by tier",
+        options=["All tiers", "Tier 1 (AI SAST agent)", "Tier 2 (rules + FP triage)", "Tier 3 (rules only)"],
+        help="Narrow the table (and its CSV/PDF export) to one tier. The estate summary above always reflects "
+             "all repositories.",
+    )
+    if tier_filter == "All tiers":
+        filtered = allocated
+    else:
+        tier_num = {v: k for k, v in TIER_LABELS.items()}[tier_filter]
+        filtered = allocated[allocated["tier"] == tier_num]
+
+    display_df = _display_frame(filtered)
+    st.caption(f"Showing {len(display_df)} of {len(allocated)} repositories.")
+    st.dataframe(display_df, use_container_width=True, height=460)
+
+    st.caption(
+        "Tier 1 = AI SAST agent (highest cost, exploitability-aware). "
+        "Tier 2 = rule-based SAST + AI FP triage. Tier 3 = rule-based rules only (free of the pool). "
+        "Recommendations are advisory."
+    )
+
+    # --- Export ---
+    st.markdown("## Export")
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    ecol1, ecol2 = st.columns(2)
+    with ecol1:
+        st.download_button("Download CSV", data=display_df.to_csv(index=False),
+                           file_name=f"ai_sast_tiers_{namespace}_{ts}.csv", mime="text/csv",
+                           use_container_width=True)
+    with ecol2:
+        pdf_data = generate_pdf(namespace, summary, display_df, confidence, params)
+        st.download_button("Download PDF", data=pdf_data,
+                           file_name=f"ai_sast_tiers_{namespace}_{ts}.pdf", mime="application/pdf",
+                           use_container_width=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_sast_tier_recommender/dashboard.py
+++ b/ai_sast_tier_recommender/dashboard.py
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt
 from reportlab.lib.pagesizes import letter, landscape
 from reportlab.lib.units import inch
 from reportlab.lib.colors import HexColor
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image as RLImage, Table, TableStyle
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image as RLImage, Table, TableStyle, PageBreak
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 
 import compute
@@ -113,11 +113,15 @@ def _parse_languages(languages_field: Any) -> Dict[str, float]:
 
 
 def fetch_repositories(namespace: str) -> pd.DataFrame:
-    """One row per repository: uuid, project (name), languages (dict), release_signal (tag count)."""
+    """One row per repository: uuid, project_uuid (parent Project), name, languages, release_signal.
+
+    Both Repository and RepositoryVersion are children of the same parent Project
+    (meta.parent_uuid = Project.uuid), so we carry project_uuid to join version counts.
+    """
     response = run_endorctl(
         [
             "api", "list", "-r", "Repository",
-            "--field-mask", "meta.name,spec.languages,spec.tags,spec.default_branch",
+            "--field-mask", "meta.name,meta.parent_uuid,spec.languages,spec.tags,spec.default_branch",
             "--list-all",
         ],
         namespace,
@@ -127,15 +131,20 @@ def fetch_repositories(namespace: str) -> pd.DataFrame:
         spec = obj.get("spec", {})
         rows.append({
             "uuid": obj.get("uuid"),
+            "project_uuid": obj.get("meta", {}).get("parent_uuid"),
             "project": obj.get("meta", {}).get("name", "unknown"),
             "languages": _parse_languages(spec.get("languages")),
             "release_signal": float(len(spec.get("tags") or [])),
         })
-    return pd.DataFrame(rows, columns=["uuid", "project", "languages", "release_signal"])
+    return pd.DataFrame(rows, columns=["uuid", "project_uuid", "project", "languages", "release_signal"])
 
 
 def fetch_monitored_version_counts(namespace: str) -> Dict[str, int]:
-    """Count of monitored RepositoryVersions per repository uuid (meta.parent_uuid)."""
+    """Count of monitored RepositoryVersions per parent **Project** uuid (meta.parent_uuid).
+
+    RepositoryVersion.meta.parent_uuid points at the Project, not the Repository —
+    so callers must join these counts on the repo's project_uuid, not its own uuid.
+    """
     response = run_endorctl(
         ["api", "list", "-r", "RepositoryVersion", "--field-mask", "meta.parent_uuid", "--list-all"],
         namespace,
@@ -229,7 +238,8 @@ def assemble_repos(namespace: str) -> pd.DataFrame:
     activity = fetch_activity(namespace)
     findings = fetch_finding_counts(namespace)
 
-    repos["monitored_versions"] = repos["uuid"].map(lambda u: mv.get(u, 1)).fillna(1).astype(int)
+    # Versions are keyed by the parent Project uuid (shared with the repo), not the repo's own uuid.
+    repos["monitored_versions"] = repos["project_uuid"].map(lambda p: mv.get(p, 1)).fillna(1).astype(int)
     repos["activity"] = repos["uuid"].map(lambda u: activity.get(u, 0.0)).fillna(0.0)
     repos["findings"] = repos["uuid"].map(lambda u: findings.get(u, 0)).fillna(0).astype(int)
     return repos
@@ -245,6 +255,56 @@ BRAND = {
 }
 
 TIER_LABELS = {1: "Tier 1 (AI SAST agent)", 2: "Tier 2 (rules + FP triage)", 3: "Tier 3 (rules only)"}
+
+# Single source of truth for column docs — rendered both in the Streamlit
+# expander and the PDF, so the two can never drift.
+COLUMN_LEGEND: List[tuple] = [
+    ("Repository", "Repo name (shortened from its URL)."),
+    ("Tier", "Recommended tier: 1 = AI SAST agent, 2 = rules + AI FP triage, 3 = rules only."),
+    ("T1 Rank", "For Tier 1 repos, the promotion order by value-per-credit (rank #1 = best value for the cost)."),
+    ("Value", "0–1 security-value score, relative to the other eligible repos in this namespace (a weighted blend "
+              "of commit activity, high-severity findings, and release/production signal). Higher = stronger AI SAST "
+              "candidate. The lowest-scoring eligible repo reads 0, and gated repos are 0."),
+    ("Est. Cost ($)", "Estimated first-window AI credits to run Tier 1 on the repo (supported-language size × "
+                      "calibrated $/KLOC × monitored-version multiplier; coarse size buckets if uncalibrated)."),
+    ("Value/Cost", "Value ÷ Est. Cost: security value per credit spent. This is the ranking key the allocator uses."),
+    ("Supported %", "Share of the repo's code (by bytes) in AI-SAST-supported languages. Below the gate → Tier 3."),
+    ("Monitored Vers.", "Number of monitored branches; each is scanned, so it raises both value and cost."),
+    ("High-sev Findings", "Count of critical/high findings; feeds the Value score and the Tier-2 cost estimate."),
+    ("Rationale", "Plain-language reason for the tier decision."),
+]
+
+# Methodology / disclaimer bullets for the report's disclaimer box.
+METHODOLOGY_NOTES: List[str] = [
+    "<b>Advisory only.</b> This report never applies scan profiles or changes quota — it is a planning aid.",
+    "<b>Language gate.</b> A repo is eligible for Tier 1/2 only if its supported-language byte share ≥ the gate "
+    "threshold; otherwise it is Tier 3, because AI SAST cannot analyze it.",
+    "<b>Value score.</b> A min-max-normalized, weighted blend of commit activity, high-severity finding density, "
+    "and release/production signal — normalized across the eligible repos in this namespace, so it is a "
+    "within-estate ranking, not an absolute rating.",
+    "<b>Cost model.</b> Estimated first-window Tier-1 cost = supported KLOC × $/KLOC rate × monitored-version "
+    "multiplier (1 + k×(versions−1)). The $/KLOC rate is a single tenant-wide blend of ALL AI spend "
+    "(SAST + FP triage + security review) ÷ scanned KLOC — not attributable per feature or per repo.",
+    "<b>Uncalibrated fallback.</b> With no observed spend, costs use coarse size buckets (~$2–$50/repo), which are "
+    "rough and typically under-price large repos.",
+    "<b>Budget packing.</b> Repos are promoted to Tier 1 by descending Value/Cost until budget × (1 − safety margin) "
+    "is committed; the safety margin absorbs estimation error.",
+]
+
+
+def _calibration_sentence(cal: Dict[str, Any]) -> str:
+    """Human-readable calibration provenance, shared by the UI and the PDF."""
+    if cal.get("rate"):
+        return (
+            f"Cost calibration: {cal['confidence']} confidence — ${cal['rate']:.4f}/KLOC blended, derived from "
+            f"{cal['scanned_repos']} already-scanned repo(s) ≈ {cal['scanned_kloc']:,.0f} KLOC and "
+            f"${cal['total_spend']:.2f} observed AI spend at root namespace '{cal['spend_ns']}'. Single tenant-wide "
+            f"rate across all AI features (SAST, FP triage, security review) — not per-feature or per-repo."
+        )
+    return (
+        f"Cost calibration: uncalibrated — no observed AI spend at root namespace '{cal['spend_ns']}', so per-repo "
+        f"costs use coarse size buckets (rough, planning-grade only)."
+    )
 
 
 def _display_frame(allocated: pd.DataFrame) -> pd.DataFrame:
@@ -290,8 +350,20 @@ def _tier_distribution_chart(summary: Dict[str, float], page_width: float) -> RL
     return _fig_to_rl_image(fig, page_width, 2.2 * 72)
 
 
+def _disclaimer_box(flowables: list, usable_width: float) -> Table:
+    """Wrap flowables in a shaded, bordered single-cell box (for the disclaimer/legend)."""
+    box = Table([[flowables]], colWidths=[usable_width])
+    box.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["table_row_alt"])),
+        ("BOX", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+        ("LEFTPADDING", (0, 0), (-1, -1), 10), ("RIGHTPADDING", (0, 0), (-1, -1), 10),
+        ("TOPPADDING", (0, 0), (-1, -1), 8), ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+    ]))
+    return box
+
+
 def generate_pdf(namespace: str, summary: Dict[str, float], display_df: pd.DataFrame,
-                  confidence: str, params: AllocationParams) -> bytes:
+                  calibration: Dict[str, Any], params: AllocationParams) -> bytes:
     buf = BytesIO()
     page_w, _ = landscape(letter)
     margin = 0.6 * inch
@@ -303,17 +375,24 @@ def generate_pdf(namespace: str, summary: Dict[str, float], display_df: pd.DataF
     styles.add(ParagraphStyle("Title2", parent=styles["Title"], fontSize=20, textColor=HexColor(BRAND["dark"]), spaceAfter=4))
     styles.add(ParagraphStyle("Subtitle", parent=styles["Normal"], fontSize=10, textColor=HexColor(BRAND["text_secondary"]), spaceAfter=12))
     styles.add(ParagraphStyle("SectionHeader", parent=styles["Heading2"], fontSize=13, textColor=HexColor(BRAND["dark"]), spaceBefore=14, spaceAfter=8))
+    styles.add(ParagraphStyle("Body", parent=styles["Normal"], fontSize=8, leading=11, textColor=HexColor(BRAND["text_primary"]), spaceAfter=4))
+    styles.add(ParagraphStyle("Note", parent=styles["Normal"], fontSize=8, leading=11, textColor=HexColor(BRAND["text_secondary"]), spaceAfter=4))
 
     elements = [Paragraph("AI SAST Tier Recommendations", styles["Title2"])]
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     elements.append(Paragraph(
         f"Namespace: {namespace}  |  Budget: ${params.budget:.2f}  |  Safety margin: {params.safety_margin * 100:.0f}%  |  "
-        f"Cost confidence: {confidence}  |  Generated: {ts}",
+        f"Cost confidence: {calibration.get('confidence', 'none')}  |  Generated: {ts}",
         styles["Subtitle"],
     ))
     divider = Table([[""]], colWidths=[usable_width], rowHeights=[3])
     divider.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, -1), HexColor(BRAND["green"]))]))
     elements.append(divider)
+    elements.append(Spacer(1, 12))
+
+    # Calibration provenance callout — the exact rate and how many repos it came from.
+    elements.append(_disclaimer_box(
+        [Paragraph(_calibration_sentence(calibration), styles["Body"])], usable_width))
     elements.append(Spacer(1, 12))
 
     summary_data = [
@@ -339,18 +418,44 @@ def generate_pdf(namespace: str, summary: Dict[str, float], display_df: pd.DataF
 
     elements.append(Paragraph("Recommendations", styles["SectionHeader"]))
     show = display_df.drop(columns=["Rationale"], errors="ignore")
-    table_rows = [list(show.columns)] + show.astype(str).values.tolist()
-    n = len(show.columns)
-    rec_table = Table(table_rows, colWidths=[usable_width / n] * n, repeatRows=1)
+    cols = list(show.columns)
+
+    # Wrapping only happens for Paragraph cells (ReportLab won't wrap raw strings),
+    # so render every cell as a Paragraph and give the text-heavy columns more width.
+    cell_style = ParagraphStyle("Cell", parent=styles["Normal"], fontSize=7, leading=8,
+                                textColor=HexColor(BRAND["text_primary"]))
+    header_style = ParagraphStyle("CellHeader", parent=styles["Normal"], fontSize=7, leading=8,
+                                  fontName="Helvetica-Bold", textColor=HexColor(BRAND["table_header_text"]))
+
+    weights = [2.4 if c == "Repository" else 1.7 if c == "Tier" else 1.0 for c in cols]
+    total = sum(weights)
+    col_widths = [usable_width * w / total for w in weights]
+
+    header = [Paragraph(str(c), header_style) for c in cols]
+    body = [[Paragraph(str(v), cell_style) for v in row] for row in show.astype(str).values.tolist()]
+    rec_table = Table([header] + body, colWidths=col_widths, repeatRows=1)
     rec_table.setStyle(TableStyle([
         ("BACKGROUND", (0, 0), (-1, 0), HexColor(BRAND["table_header_bg"])),
-        ("TEXTCOLOR", (0, 0), (-1, 0), HexColor(BRAND["table_header_text"])),
-        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
-        ("FONTSIZE", (0, 0), (-1, -1), 7), ("ALIGN", (1, 0), (-1, -1), "CENTER"),
-        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"), ("GRID", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("GRID", (0, 0), (-1, -1), 0.5, HexColor(BRAND["table_border"])),
         ("ROWBACKGROUNDS", (0, 1), (-1, -1), [HexColor(BRAND["white"]), HexColor(BRAND["table_row_alt"])]),
+        ("LEFTPADDING", (0, 0), (-1, -1), 3), ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+        ("TOPPADDING", (0, 0), (-1, -1), 2), ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
     ]))
     elements.append(rec_table)
+
+    # Reference appendix: column legend + methodology/disclaimers, on a fresh page.
+    elements.append(PageBreak())
+    elements.append(Paragraph("Column legends", styles["SectionHeader"]))
+    legend_paras = [
+        Paragraph(f"<b>{name}</b> — {desc}", styles["Body"]) for name, desc in COLUMN_LEGEND
+    ]
+    elements.append(_disclaimer_box(legend_paras, usable_width))
+    elements.append(Spacer(1, 12))
+
+    elements.append(Paragraph("Methodology &amp; disclaimers", styles["SectionHeader"]))
+    method_paras = [Paragraph(f"• {note}", styles["Note"]) for note in METHODOLOGY_NOTES]
+    elements.append(_disclaimer_box(method_paras, usable_width))
 
     doc.build(elements)
     return buf.getvalue()
@@ -360,7 +465,7 @@ def main():
     st.set_page_config(page_title="AI SAST Tier Recommender", page_icon="\U0001F6E1",
                        layout="wide", initial_sidebar_state="expanded")
 
-    for key in ("repos_df", "license_info", "namespace", "total_spend"):
+    for key in ("repos_df", "license_info", "namespace", "total_spend", "spend_ns"):
         st.session_state.setdefault(key, None)
 
     st.title("AI SAST Tier Recommender")
@@ -391,13 +496,17 @@ def main():
         if not license_info:
             st.error("Could not read AI credit quota (EndorLicense.spec.quota.ai_limit) for this namespace.")
             st.stop()
+        # AICreditMetric is root-only and non-local — it never surfaces from a
+        # child/app namespace, so calibration spend must be read at the tenant root.
+        spend_ns = compute.root_namespace(namespace)
         with st.spinner("Fetching repositories and signals (this can take a minute)..."):
             repos_df = assemble_repos(namespace)
-            total_spend = fetch_total_ai_spend(namespace)
+            total_spend = fetch_total_ai_spend(spend_ns)
         st.session_state.repos_df = repos_df
         st.session_state.license_info = license_info
         st.session_state.namespace = namespace
         st.session_state.total_spend = total_spend
+        st.session_state.spend_ns = spend_ns
         st.rerun()
 
     if st.session_state.license_info is None:
@@ -408,6 +517,7 @@ def main():
     repos_df = st.session_state.repos_df
     namespace = st.session_state.namespace
     total_spend = st.session_state.total_spend or 0.0
+    spend_ns = st.session_state.spend_ns or namespace
 
     if repos_df is None or repos_df.empty:
         st.warning("No repositories found in this namespace.")
@@ -464,7 +574,7 @@ def main():
         )
         st.markdown("---")
         st.subheader("Cost calibration")
-        st.caption(f"Observed AI spend (trailing 180d): ${total_spend:.2f}")
+        st.caption(f"Observed AI spend (trailing 180d, from root `{spend_ns}`): ${total_spend:.2f}")
         scanned_repos = st.multiselect(
             "Calibrate cost from already-scanned repos",
             options=sorted(repos_df["project"].tolist()),
@@ -486,6 +596,10 @@ def main():
             st.caption(f"Selected: {len(scanned_repos)} repos ≈ {scanned_kloc:,.0f} KLOC supported-language code")
 
     rate, confidence = compute.calibrate_cost_per_kloc(total_spend, scanned_kloc)
+    calibration = {
+        "confidence": confidence, "rate": rate, "scanned_repos": len(scanned_repos),
+        "scanned_kloc": scanned_kloc, "total_spend": total_spend, "spend_ns": spend_ns,
+    }
 
     params = AllocationParams(
         budget=budget, safety_margin=safety_margin,
@@ -499,12 +613,26 @@ def main():
     # --- Summary ---
     st.markdown("## Estate Summary")
     if confidence == "none":
-        st.warning(
-            "**Cost is uncalibrated** — no scanned-KLOC entered, so estimates use coarse size buckets. "
-            "Enter KLOC already scanned in the sidebar (and rely on the safety margin) for a real fit."
-        )
+        if total_spend <= 0:
+            st.warning(
+                f"**Cost is uncalibrated** — no AI spend found at root namespace `{spend_ns}` "
+                f"(observed: ${total_spend:.2f}). `AICreditMetric` is stored **only** at the tenant root "
+                "(and only when the license's `ai_limit.days` > 0), so a child/app namespace always reads $0. "
+                "Estimates fall back to coarse size buckets. Sanity-check with "
+                f"`endorctl -n {spend_ns} api list -r AICreditMetric --count`."
+            )
+        else:
+            st.warning(
+                "**Cost is uncalibrated** — spend was found, but no already-scanned repos are selected "
+                "(or the selected repos have 0 supported-language KLOC). Pick your AI-SAST-baselined repos "
+                "in the sidebar to derive a $/KLOC rate; otherwise estimates use coarse size buckets."
+            )
     else:
-        st.info(f"Cost calibration: **{confidence}** confidence (${rate:.4f}/KLOC blended, tenant-wide — not per-feature or per-repo).")
+        st.info(
+            f"Cost calibration: **{confidence}** confidence — ${rate:.4f}/KLOC blended, derived from "
+            f"**{len(scanned_repos)}** already-scanned repo(s) ≈ {scanned_kloc:,.0f} KLOC and ${total_spend:.2f} "
+            f"observed spend at root `{spend_ns}`. Tenant-wide rate across all AI features — not per-feature or per-repo."
+        )
 
     c1, c2, c3, c4, c5, c6 = st.columns(6)
     c1.metric("Tier 1", summary["tier1_count"])
@@ -530,6 +658,9 @@ def main():
         tier_num = {v: k for k, v in TIER_LABELS.items()}[tier_filter]
         filtered = allocated[allocated["tier"] == tier_num]
 
+    with st.expander("Column legends"):
+        st.markdown("\n".join(f"- **{name}** — {desc}" for name, desc in COLUMN_LEGEND))
+
     display_df = _display_frame(filtered)
     st.caption(f"Showing {len(display_df)} of {len(allocated)} repositories.")
     st.dataframe(display_df, use_container_width=True, height=460)
@@ -549,7 +680,7 @@ def main():
                            file_name=f"ai_sast_tiers_{namespace}_{ts}.csv", mime="text/csv",
                            use_container_width=True)
     with ecol2:
-        pdf_data = generate_pdf(namespace, summary, display_df, confidence, params)
+        pdf_data = generate_pdf(namespace, summary, display_df, calibration, params)
         st.download_button("Download PDF", data=pdf_data,
                            file_name=f"ai_sast_tiers_{namespace}_{ts}.pdf", mime="application/pdf",
                            use_container_width=True)

--- a/ai_sast_tier_recommender/dashboard.py
+++ b/ai_sast_tier_recommender/dashboard.py
@@ -203,17 +203,20 @@ def _find_time_tracker(node: Any) -> Optional[Dict[str, Any]]:
 
 
 def fetch_finding_counts(namespace: str) -> Dict[str, int]:
-    """Best-effort count of high-severity findings per repository uuid.
+    """Best-effort count of high/critical findings per **project** uuid (spec.project_uuid).
 
-    Findings taxonomy varies; this is intentionally coarse and defaults to
-    empty (so the findings component scores 0) rather than failing the run.
+    A Finding can be parented to Repository, RepositoryVersion, or PackageVersion,
+    but every finding carries spec.project_uuid — the stable key the platform uses to
+    tie findings back to a project. Joining on that (not meta.parent_uuid) is what makes
+    the count match the platform's per-project totals. Defaults to empty on error so the
+    findings component scores 0 rather than failing the run.
     """
     try:
         response = run_endorctl(
             [
                 "api", "list", "-r", "Finding",
                 "--filter", "spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH",
-                "--field-mask", "meta.parent_uuid", "--list-all",
+                "--field-mask", "spec.project_uuid", "--list-all",
             ],
             namespace,
         )
@@ -222,9 +225,9 @@ def fetch_finding_counts(namespace: str) -> Dict[str, int]:
 
     counts: Dict[str, int] = {}
     for obj in _objects(response):
-        parent = obj.get("meta", {}).get("parent_uuid")
-        if parent:
-            counts[parent] = counts.get(parent, 0) + 1
+        project_uuid = obj.get("spec", {}).get("project_uuid")
+        if project_uuid:
+            counts[project_uuid] = counts.get(project_uuid, 0) + 1
     return counts
 
 
@@ -241,7 +244,8 @@ def assemble_repos(namespace: str) -> pd.DataFrame:
     # Versions are keyed by the parent Project uuid (shared with the repo), not the repo's own uuid.
     repos["monitored_versions"] = repos["project_uuid"].map(lambda p: mv.get(p, 1)).fillna(1).astype(int)
     repos["activity"] = repos["uuid"].map(lambda u: activity.get(u, 0.0)).fillna(0.0)
-    repos["findings"] = repos["uuid"].map(lambda u: findings.get(u, 0)).fillna(0).astype(int)
+    # Findings join on the project uuid (spec.project_uuid), not the repo's own uuid.
+    repos["findings"] = repos["project_uuid"].map(lambda p: findings.get(p, 0)).fillna(0).astype(int)
     return repos
 
 

--- a/ai_sast_tier_recommender/dashboard.py
+++ b/ai_sast_tier_recommender/dashboard.py
@@ -16,7 +16,7 @@ import json
 import subprocess
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import streamlit as st
@@ -139,22 +139,21 @@ def fetch_repositories(namespace: str) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=["uuid", "project_uuid", "project", "languages", "release_signal"])
 
 
-def fetch_monitored_version_counts(namespace: str) -> Dict[str, int]:
-    """Count of monitored RepositoryVersions per parent **Project** uuid (meta.parent_uuid).
+def fetch_repository_versions(namespace: str) -> List[Dict[str, Any]]:
+    """Raw RepositoryVersion objects with parent Project uuid + AI SAST scan status.
 
-    RepositoryVersion.meta.parent_uuid points at the Project, not the Repository —
-    so callers must join these counts on the repo's project_uuid, not its own uuid.
+    One pull feeds both the monitored-version counts and the AI-SAST-scanned inference
+    (compute.monitored_version_counts / compute.ai_sast_scanned_projects). Counts key on
+    meta.parent_uuid, which points at the Project, not the Repository.
     """
     response = run_endorctl(
-        ["api", "list", "-r", "RepositoryVersion", "--field-mask", "meta.parent_uuid", "--list-all"],
+        [
+            "api", "list", "-r", "RepositoryVersion",
+            "--field-mask", "meta.parent_uuid,scan_object.aisast_status", "--list-all",
+        ],
         namespace,
     )
-    counts: Dict[str, int] = {}
-    for obj in _objects(response):
-        parent = obj.get("meta", {}).get("parent_uuid")
-        if parent:
-            counts[parent] = counts.get(parent, 0) + 1
-    return counts
+    return _objects(response)
 
 
 def fetch_activity(namespace: str) -> Dict[str, float]:
@@ -240,13 +239,20 @@ def fetch_finding_counts(namespace: str) -> Dict[str, int]:
     return counts
 
 
-def assemble_repos(namespace: str) -> pd.DataFrame:
-    """Fetch and join all per-repo signals into the allocator's input frame."""
+def assemble_repos(namespace: str) -> Tuple[pd.DataFrame, set]:
+    """Fetch and join all per-repo signals into the allocator's input frame.
+
+    Returns (repos_df, ai_sast_scanned_project_uuids); the latter drives the
+    "auto-detect scanned repos" button in the cost-calibration sidebar.
+    """
     repos = fetch_repositories(namespace)
     if repos.empty:
-        return repos.assign(monitored_versions=pd.Series(dtype="int"),
-                            activity=pd.Series(dtype="float"), findings=pd.Series(dtype="int"))
-    mv = fetch_monitored_version_counts(namespace)
+        empty = repos.assign(monitored_versions=pd.Series(dtype="int"),
+                             activity=pd.Series(dtype="float"), findings=pd.Series(dtype="int"))
+        return empty, set()
+    versions = fetch_repository_versions(namespace)
+    mv = compute.monitored_version_counts(versions)
+    scanned_project_uuids = compute.ai_sast_scanned_projects(versions)
     activity = fetch_activity(namespace)
     findings = fetch_finding_counts(namespace)
 
@@ -255,7 +261,7 @@ def assemble_repos(namespace: str) -> pd.DataFrame:
     repos["activity"] = repos["uuid"].map(lambda u: activity.get(u, 0.0)).fillna(0.0)
     # Findings join on the project uuid (spec.project_uuid), not the repo's own uuid.
     repos["findings"] = repos["project_uuid"].map(lambda p: findings.get(p, 0)).fillna(0).astype(int)
-    return repos
+    return repos, scanned_project_uuids
 
 
 # --- Presentation ---
@@ -479,8 +485,9 @@ def main():
     st.set_page_config(page_title="AI SAST Tier Recommender", page_icon="\U0001F6E1",
                        layout="wide", initial_sidebar_state="expanded")
 
-    for key in ("repos_df", "license_info", "namespace", "total_spend", "spend_ns"):
+    for key in ("repos_df", "license_info", "namespace", "total_spend", "spend_ns", "scanned_project_uuids"):
         st.session_state.setdefault(key, None)
+    st.session_state.setdefault("scanned_repos", [])
 
     st.title("AI SAST Tier Recommender")
     st.markdown(
@@ -514,9 +521,10 @@ def main():
         # child/app namespace, so calibration spend must be read at the tenant root.
         spend_ns = compute.root_namespace(namespace)
         with st.spinner("Fetching repositories and signals (this can take a minute)..."):
-            repos_df = assemble_repos(namespace)
+            repos_df, scanned_project_uuids = assemble_repos(namespace)
             total_spend = fetch_total_ai_spend(spend_ns)
         st.session_state.repos_df = repos_df
+        st.session_state.scanned_project_uuids = scanned_project_uuids
         st.session_state.license_info = license_info
         st.session_state.namespace = namespace
         st.session_state.total_spend = total_spend
@@ -590,14 +598,33 @@ def main():
         st.markdown("---")
         st.subheader("Cost calibration")
         st.caption(f"Observed AI spend (trailing 180d, from root `{spend_ns}`): ${total_spend:.2f}")
+
+        options = sorted(repos_df["project"].tolist())
+        scanned_pids = st.session_state.get("scanned_project_uuids") or set()
+        inferred_scanned = sorted(repos_df.loc[repos_df["project_uuid"].isin(scanned_pids), "project"].tolist())
+
+        if st.button(
+            f"Auto-detect scanned repos ({len(inferred_scanned)})",
+            use_container_width=True,
+            help="Infers which repos have already been AI SAST scanned from "
+                 "`RepositoryVersion.scan_object.aisast_status` (indexed or successfully scanned) and "
+                 "selects them below. Nothing is scanned or charged — it only reads existing scan state. "
+                 "You can still adjust the selection by hand afterward.",
+        ):
+            st.session_state["scanned_repos"] = inferred_scanned
+            st.rerun()
+
+        # Drop stale selections not in the current options (e.g. after switching namespace)
+        # so the keyed multiselect doesn't raise; safe to set before the widget is created.
+        st.session_state["scanned_repos"] = [r for r in st.session_state.get("scanned_repos", []) if r in options]
         scanned_repos = st.multiselect(
             "Calibrate cost from already-scanned repos",
-            options=sorted(repos_df["project"].tolist()),
-            default=[],
+            options=options,
+            key="scanned_repos",
             format_func=compute.short_repo_name,
             help=(
-                "Pick the repos you've already AI-SAST baselined. The tool sums their "
-                "supported-language size (KLOC) and divides your observed AI spend by it to get a "
+                "Pick the repos you've already AI-SAST baselined (or use **Auto-detect** above). The tool sums "
+                "their supported-language size (KLOC) and divides your observed AI spend by it to get a "
                 "blended **$/KLOC** rate.\n\n"
                 "That rate sets the **Est. Cost** for every repo, which drives **Projected Spend**, "
                 "**Headroom**, and which repos get promoted to Tier 1 (allocation is budget-aware).\n\n"

--- a/ai_sast_tier_recommender/dashboard.py
+++ b/ai_sast_tier_recommender/dashboard.py
@@ -203,19 +203,28 @@ def _find_time_tracker(node: Any) -> Optional[Dict[str, Any]]:
 
 
 def fetch_finding_counts(namespace: str) -> Dict[str, int]:
-    """Best-effort count of high/critical findings per **project** uuid (spec.project_uuid).
+    """Count of high/critical **SAST** findings on the default branch, per project uuid.
 
-    A Finding can be parented to Repository, RepositoryVersion, or PackageVersion,
-    but every finding carries spec.project_uuid — the stable key the platform uses to
-    tie findings back to a project. Joining on that (not meta.parent_uuid) is what makes
-    the count match the platform's per-project totals. Defaults to empty on error so the
-    findings component scores 0 rather than failing the run.
+    Three scoping decisions, each matching how the platform reports findings:
+      - spec.project_uuid: a Finding can be parented to Repository, RepositoryVersion,
+        or PackageVersion, but every finding carries spec.project_uuid — the stable key
+        the platform uses to tie findings to a project (joining on meta.parent_uuid missed
+        the per-branch RepositoryVersion findings).
+      - context.type == CONTEXT_TYPE_MAIN: only the default-branch context, so findings
+        aren't multiplied across a repo's monitored release branches.
+      - FINDING_CATEGORY_SAST: AI SAST (Tier 1) and rule-based SAST (Tier 2) only act on
+        SAST findings — SCA/secrets are irrelevant to the tier decision.
+
+    Defaults to empty on error so the findings component scores 0 rather than failing.
     """
     try:
         response = run_endorctl(
             [
                 "api", "list", "-r", "Finding",
-                "--filter", "spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH",
+                "--filter",
+                "context.type == CONTEXT_TYPE_MAIN and "
+                "(spec.level == FINDING_LEVEL_CRITICAL or spec.level == FINDING_LEVEL_HIGH) and "
+                "spec.finding_categories contains [FINDING_CATEGORY_SAST]",
                 "--field-mask", "spec.project_uuid", "--list-all",
             ],
             namespace,
@@ -274,7 +283,8 @@ COLUMN_LEGEND: List[tuple] = [
     ("Value/Cost", "Value ÷ Est. Cost: security value per credit spent. This is the ranking key the allocator uses."),
     ("Supported %", "Share of the repo's code (by bytes) in AI-SAST-supported languages. Below the gate → Tier 3."),
     ("Monitored Vers.", "Number of monitored branches; each is scanned, so it raises both value and cost."),
-    ("High-sev Findings", "Count of critical/high findings; feeds the Value score and the Tier-2 cost estimate."),
+    ("High-sev SAST", "Count of critical/high SAST findings on the default branch (SCA and secrets are excluded, "
+                      "since AI SAST doesn't address them). Feeds the Value score and the Tier-2 cost estimate."),
     ("Rationale", "Plain-language reason for the tier decision."),
 ]
 
@@ -283,9 +293,9 @@ METHODOLOGY_NOTES: List[str] = [
     "<b>Advisory only.</b> This report never applies scan profiles or changes quota — it is a planning aid.",
     "<b>Language gate.</b> A repo is eligible for Tier 1/2 only if its supported-language byte share ≥ the gate "
     "threshold; otherwise it is Tier 3, because AI SAST cannot analyze it.",
-    "<b>Value score.</b> A min-max-normalized, weighted blend of commit activity, high-severity finding density, "
-    "and release/production signal — normalized across the eligible repos in this namespace, so it is a "
-    "within-estate ranking, not an absolute rating.",
+    "<b>Value score.</b> A min-max-normalized, weighted blend of commit activity, high-severity SAST finding "
+    "density (default branch, SCA/secrets excluded), and release/production signal — normalized across the "
+    "eligible repos in this namespace, so it is a within-estate ranking, not an absolute rating.",
     "<b>Cost model.</b> Estimated first-window Tier-1 cost = supported KLOC × $/KLOC rate × monitored-version "
     "multiplier (1 + k×(versions−1)). The $/KLOC rate is a single tenant-wide blend of ALL AI spend "
     "(SAST + FP triage + security review) ÷ scanned KLOC — not attributable per feature or per repo.",
@@ -326,7 +336,7 @@ def _display_frame(allocated: pd.DataFrame) -> pd.DataFrame:
     return df.rename(columns={
         "project": "Repository", "tier": "Tier", "rank": "T1 Rank", "value": "Value",
         "est_cost": "Est. Cost ($)", "vc_ratio": "Value/Cost", "supported_share": "Supported %",
-        "monitored_versions": "Monitored Vers.", "findings": "High-sev Findings", "rationale": "Rationale",
+        "monitored_versions": "Monitored Vers.", "findings": "High-sev SAST", "rationale": "Rationale",
     })
 
 
@@ -568,8 +578,9 @@ def main():
         )
         w_findings = st.slider(
             "Findings", 0.0, 1.0, compute.DEFAULT_WEIGHTS["findings"], 0.05,
-            help="Weight of high-severity finding density in the value score — where AI SAST's exploitability "
-                 "reasoning pays off most. Weights are normalized, so only their ratios matter.",
+            help="Weight of high-severity SAST finding density (default branch; SCA/secrets excluded) in the value "
+                 "score — where AI SAST's exploitability reasoning pays off most. Weights are normalized, so only "
+                 "their ratios matter.",
         )
         w_release = st.slider(
             "Release/prod", 0.0, 1.0, compute.DEFAULT_WEIGHTS["release"], 0.05,

--- a/ai_sast_tier_recommender/requirements.txt
+++ b/ai_sast_tier_recommender/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.28.0
+pandas>=2.0.0
+altair>=5.0.0
+matplotlib>=3.7.0
+reportlab>=4.0.0

--- a/ai_sast_tier_recommender/tests/conftest.py
+++ b/ai_sast_tier_recommender/tests/conftest.py
@@ -1,0 +1,4 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))

--- a/ai_sast_tier_recommender/tests/test_compute.py
+++ b/ai_sast_tier_recommender/tests/test_compute.py
@@ -26,6 +26,13 @@ def test_short_repo_name_strips_url_and_git():
     assert compute.short_repo_name("") == ""
 
 
+def test_root_namespace_takes_first_segment():
+    assert compute.root_namespace("american-credit-acceptance.acacceptance-appdev") == "american-credit-acceptance"
+    assert compute.root_namespace("acme.team.subproject") == "acme"
+    assert compute.root_namespace("root-only") == "root-only"
+    assert compute.root_namespace("") == ""
+
+
 def test_supported_language_share_mixed():
     langs = {"Java": 800.0, "HTML": 200.0}
     assert compute.supported_language_share(langs) == 0.8

--- a/ai_sast_tier_recommender/tests/test_compute.py
+++ b/ai_sast_tier_recommender/tests/test_compute.py
@@ -1,0 +1,190 @@
+import pandas as pd
+
+import compute
+from compute import AllocationParams
+
+
+# --- language gate ---
+
+def test_normalize_language_aliases():
+    assert compute.normalize_language("Java") == "java"
+    assert compute.normalize_language("C++") == "cpp"
+    assert compute.normalize_language("C#") == "csharp"
+    assert compute.normalize_language("golang") == "go"
+    assert compute.normalize_language("TypeScript") == "typescript"
+
+
+def test_normalize_language_unsupported_returns_none():
+    assert compute.normalize_language("COBOL") is None
+    assert compute.normalize_language("HTML") is None
+
+
+def test_short_repo_name_strips_url_and_git():
+    assert compute.short_repo_name("https://github.com/acacceptance-platform/pr-agent-settings.git") == "pr-agent-settings"
+    assert compute.short_repo_name("org/repo") == "repo"
+    assert compute.short_repo_name("just-a-name") == "just-a-name"
+    assert compute.short_repo_name("") == ""
+
+
+def test_supported_language_share_mixed():
+    langs = {"Java": 800.0, "HTML": 200.0}
+    assert compute.supported_language_share(langs) == 0.8
+
+
+def test_supported_language_share_empty_is_zero():
+    assert compute.supported_language_share({}) == 0.0
+    assert compute.supported_language_share(None) == 0.0
+
+
+def test_passes_language_gate_threshold():
+    assert compute.passes_language_gate(0.5, 0.5) is True
+    assert compute.passes_language_gate(0.49, 0.5) is False
+
+
+def test_supported_kloc_only_counts_supported_bytes():
+    langs = {"Java": 30000.0, "COBOL": 30000.0}  # 30 bytes/line default -> 1 KLOC supported
+    assert compute.supported_kloc(langs) == 1.0
+
+
+# --- cost model ---
+
+def test_total_supported_kloc_sums_across_repos():
+    maps = [{"Java": 30000.0}, {"Python": 60000.0, "HTML": 90000.0}]  # 1 + 2 KLOC supported
+    assert compute.total_supported_kloc(maps) == 3.0
+
+
+def test_total_supported_kloc_empty_is_zero():
+    assert compute.total_supported_kloc([]) == 0.0
+
+
+def test_calibrate_cost_per_kloc_none_when_no_data():
+    rate, conf = compute.calibrate_cost_per_kloc(total_spend=0.0, total_scanned_kloc=0.0)
+    assert rate is None
+    assert conf == "none"
+
+
+def test_calibrate_cost_per_kloc_low_and_medium():
+    rate, conf = compute.calibrate_cost_per_kloc(total_spend=50.0, total_scanned_kloc=50.0)
+    assert rate == 1.0
+    assert conf == "low"
+    _, conf2 = compute.calibrate_cost_per_kloc(total_spend=200.0, total_scanned_kloc=200.0)
+    assert conf2 == "medium"
+
+
+def test_monitored_version_multiplier():
+    assert compute.monitored_version_multiplier(1) == 1.0
+    assert compute.monitored_version_multiplier(3, k=0.3) == 1.6
+    assert compute.monitored_version_multiplier(0) == 1.0  # floored at 1 version
+
+
+def test_size_bucket_cost_bands():
+    assert compute.size_bucket_cost(5) == 2.0
+    assert compute.size_bucket_cost(40) == 6.0
+    assert compute.size_bucket_cost(150) == 20.0
+    assert compute.size_bucket_cost(500) == compute.SIZE_BUCKET_LARGE_COST
+
+
+def test_estimate_tier1_cost_uses_rate_and_multiplier():
+    # 10 KLOC * $2/KLOC * (1 + 0.3*(2-1)) = 20 * 1.3 = 26
+    assert compute.estimate_tier1_cost(kloc=10.0, rate=2.0, monitored_versions=2, k=0.3) == 26.0
+
+
+def test_estimate_tier1_cost_falls_back_to_buckets_when_uncalibrated():
+    # rate None, 5 KLOC -> bucket $2, single version -> 2.0
+    assert compute.estimate_tier1_cost(kloc=5.0, rate=None, monitored_versions=1) == 2.0
+
+
+def test_estimate_tier2_cost_scales_with_findings():
+    assert compute.estimate_tier2_cost(10, per_finding=0.02) == 0.2
+    assert compute.estimate_tier2_cost(0) == 0.0
+
+
+# --- value scoring ---
+
+def test_normalize_series_min_max():
+    s = pd.Series([0.0, 5.0, 10.0])
+    result = compute.normalize_series(s)
+    assert list(result) == [0.0, 0.5, 1.0]
+
+
+def test_normalize_series_all_equal_is_zero():
+    s = pd.Series([4.0, 4.0, 4.0])
+    assert list(compute.normalize_series(s)) == [0.0, 0.0, 0.0]
+
+
+def test_value_score_weighted_blend():
+    components = {"activity": 1.0, "findings": 0.0, "release": 0.5}
+    weights = {"activity": 1.0, "findings": 1.0, "release": 2.0}
+    # (1*1 + 0*1 + 0.5*2) / 4 = 2/4 = 0.5
+    assert compute.value_score(components, weights) == 0.5
+
+
+# --- allocator ---
+
+def _repo(project, langs, mv=1, activity=0.0, findings=0, release=0.0):
+    return {"project": project, "languages": langs, "monitored_versions": mv,
+            "activity": activity, "findings": findings, "release_signal": release}
+
+
+def test_allocate_language_gated_repo_is_tier3():
+    repos = pd.DataFrame([_repo("legacy", {"COBOL": 1000.0})])
+    params = AllocationParams(budget=1000.0, cost_rate=1.0)
+    result = compute.allocate_tiers(repos, params)
+    assert result.iloc[0]["tier"] == 3
+    assert "supported-language" in result.iloc[0]["rationale"]
+
+
+def test_allocate_promotes_high_value_to_tier1_within_budget():
+    repos = pd.DataFrame([
+        _repo("crown", {"Java": 30000.0}, mv=1, activity=10, findings=5, release=3),
+        _repo("quiet", {"Java": 30000.0}, mv=1, activity=0, findings=0, release=0),
+    ])
+    params = AllocationParams(budget=1000.0, safety_margin=0.0, cost_rate=1.0)
+    result = compute.allocate_tiers(repos, params).set_index("project")
+    assert result.loc["crown", "tier"] == 1
+    assert result.loc["crown", "rank"] == 1
+
+
+def test_allocate_respects_budget_cap_demotes_overflow():
+    # Two eligible repos, budget only fits one Tier 1 baseline.
+    repos = pd.DataFrame([
+        _repo("a", {"Java": 30000.0}, activity=10, findings=1, release=1),
+        _repo("b", {"Java": 30000.0}, activity=1, findings=0, release=0),
+    ])
+    # kloc=1 each, rate=$5 -> cost $5 each; budget 6, margin 0 -> only one fits
+    params = AllocationParams(budget=6.0, safety_margin=0.0, cost_rate=5.0)
+    result = compute.allocate_tiers(repos, params).set_index("project")
+    assert result.loc["a", "tier"] == 1  # higher value promoted first
+    assert result.loc["b", "tier"] == 3  # no findings, and budget exhausted
+
+
+def test_allocate_eligible_with_findings_gets_tier2_when_not_promoted():
+    repos = pd.DataFrame([
+        _repo("a", {"Java": 30000.0}, activity=10, findings=1, release=1),
+        _repo("b", {"Java": 30000.0}, activity=1, findings=8, release=0),
+    ])
+    # a costs $5 (fits in Tier1); b costs $5 (doesn't fit Tier1 under cap) but has findings -> Tier 2
+    params = AllocationParams(budget=6.0, safety_margin=0.0, cost_rate=5.0)
+    result = compute.allocate_tiers(repos, params).set_index("project")
+    assert result.loc["a", "tier"] == 1
+    assert result.loc["b", "tier"] == 2
+
+
+def test_allocate_empty_frame_returns_empty_with_columns():
+    repos = pd.DataFrame(columns=["project", "languages", "monitored_versions", "activity", "findings", "release_signal"])
+    result = compute.allocate_tiers(repos, AllocationParams(budget=100.0))
+    assert result.empty
+    assert "tier" in result.columns
+
+
+def test_allocation_summary_counts_and_headroom():
+    repos = pd.DataFrame([
+        _repo("a", {"Java": 30000.0}, activity=10, findings=1, release=1),
+        _repo("b", {"COBOL": 30000.0}),
+    ])
+    params = AllocationParams(budget=100.0, safety_margin=0.0, cost_rate=1.0)
+    allocated = compute.allocate_tiers(repos, params)
+    summary = compute.allocation_summary(allocated, params)
+    assert summary["tier1_count"] + summary["tier2_count"] + summary["tier3_count"] == 2
+    assert summary["tier3_count"] >= 1  # COBOL repo gated
+    assert summary["usable_budget"] == 100.0

--- a/ai_sast_tier_recommender/tests/test_compute.py
+++ b/ai_sast_tier_recommender/tests/test_compute.py
@@ -20,14 +20,14 @@ def test_normalize_language_unsupported_returns_none():
 
 
 def test_short_repo_name_strips_url_and_git():
-    assert compute.short_repo_name("https://github.com/acacceptance-platform/pr-agent-settings.git") == "pr-agent-settings"
+    assert compute.short_repo_name("https://github.com/acme-platform/pr-agent-settings.git") == "pr-agent-settings"
     assert compute.short_repo_name("org/repo") == "repo"
     assert compute.short_repo_name("just-a-name") == "just-a-name"
     assert compute.short_repo_name("") == ""
 
 
 def test_root_namespace_takes_first_segment():
-    assert compute.root_namespace("american-credit-acceptance.acacceptance-appdev") == "american-credit-acceptance"
+    assert compute.root_namespace("acme-corp.acme-appdev") == "acme-corp"
     assert compute.root_namespace("acme.team.subproject") == "acme"
     assert compute.root_namespace("root-only") == "root-only"
     assert compute.root_namespace("") == ""
@@ -62,6 +62,36 @@ def test_total_supported_kloc_sums_across_repos():
 
 def test_total_supported_kloc_empty_is_zero():
     assert compute.total_supported_kloc([]) == 0.0
+
+
+def test_monitored_version_counts_by_parent_project():
+    versions = [
+        {"meta": {"parent_uuid": "proj-a"}},
+        {"meta": {"parent_uuid": "proj-a"}},
+        {"meta": {"parent_uuid": "proj-b"}},
+        {"meta": {}},  # no parent -> ignored
+    ]
+    assert compute.monitored_version_counts(versions) == {"proj-a": 2, "proj-b": 1}
+
+
+def test_ai_sast_scanned_projects_detects_indexed_or_scanned():
+    versions = [
+        {"meta": {"parent_uuid": "indexed"},
+         "scan_object": {"aisast_status": {"last_full_index_time": "2026-07-01T00:00:00Z"}}},
+        {"meta": {"parent_uuid": "scanned"},
+         "scan_object": {"aisast_status": {"last_scan_state": "AISAST_SCAN_STATE_SCAN_SUCCEEDED"}}},
+        {"meta": {"parent_uuid": "sha-only"},
+         "scan_object": {"aisast_status": {"last_full_index_sha": "abc123"}}},
+        {"meta": {"parent_uuid": "never"},
+         "scan_object": {"aisast_status": {"last_scan_state": "AISAST_SCAN_STATE_UNSPECIFIED"}}},
+        {"meta": {"parent_uuid": "no-status"}, "scan_object": {}},
+        {"meta": {"parent_uuid": "no-scan-object"}},
+    ]
+    assert compute.ai_sast_scanned_projects(versions) == {"indexed", "scanned", "sha-only"}
+
+
+def test_ai_sast_scanned_projects_empty():
+    assert compute.ai_sast_scanned_projects([]) == set()
 
 
 def test_calibrate_cost_per_kloc_none_when_no_data():


### PR DESCRIPTION
## Summary

Streamlit tool that recommends an AI SAST **tier (1/2/3)** per repository in a namespace, maximizing security value while fitting the tenant's AI credit budget, with an **explainable rationale per repo**. **Advisory only** — it never applies scan profiles or changes quota. Tier-planning companion to `ai_credit_dashboard`.

Mirrors that dashboard's pattern: pure, unit-tested logic in `compute.py`; all `endorctl`/Streamlit I/O and CSV/PDF export in `dashboard.py`. A language hard-gate + value scoring + a calibrated (or size-bucket) cost model feed a greedy value-density allocator.

## How it decides

1. **Language gate (hard):** repos below the supported-language byte-share threshold (default 50%) go straight to Tier 3 — AI SAST can't help them.
2. **Value score (0–1):** tunable blend of commit **activity**, high-severity **SAST findings** (default branch, SCA/secrets excluded), and **release/production** signal, normalized across eligible repos.
3. **Cost estimate:** a tenant-wide blended `$/KLOC` (observed spend ÷ scanned KLOC) scaled by repo size and a monitored-version multiplier; coarse size buckets when uncalibrated.
4. **Greedy allocation:** repos ranked by **value ÷ cost**, promoted to Tier 1 until budget × (1 − safety margin) is committed; remaining eligible repos with findings become Tier 2; the rest Tier 3.

## Key details / correctness

- **Cost calibration reads the tenant root.** `AICreditMetric` is a root-only, non-local resource, so spend is fetched at the root namespace (a child/app namespace reads $0). Self-diagnosing banner when uncalibrated.
- **Auto-detect scanned repos** button infers the calibration set from `RepositoryVersion.scan_object.aisast_status` (indexed or successfully scanned) — no manual picking. Read-only; nothing is scanned or charged.
- **Correct join keys** (both were silent parent-mismatch bugs):
  - Monitored versions join on the parent **Project** uuid (`RepositoryVersion` is parented to Project, not Repository).
  - Findings join on **`spec.project_uuid`**, scoped to `context.type == CONTEXT_TYPE_MAIN` and `FINDING_CATEGORY_SAST` (high/critical) — matches the platform's per-project totals and avoids multiplying across release branches.
- **Branded PDF report:** estate summary, tier-distribution chart, per-repo recommendations (long names wrap), a cost-calibration provenance callout, a shared column legend, and a methodology/disclaimer box. CSV export too.
- **Runs on port 8502** (`.streamlit/config.toml`) so it can run alongside `ai_credit_dashboard` (8501).

## Test plan

- [x] `pytest` — 29 unit tests pass (`compute.py` logic: language gate, cost model, value scoring, allocator, calibration, version/finding/scan-status parsing).
- [x] PDF render verified end-to-end (calibrated + uncalibrated); table/PDF value parity confirmed by extracting text from the generated PDF.
- [x] Validated against the a prod customer namespace (~454 repos): monitored-version and SAST-finding counts reconcile with the platform.
